### PR TITLE
[UI]: 어드민 사이드바 레이아웃 패딩 크기 변경 (QA)

### DIFF
--- a/apps/recruit/src/app/admin/(with-sidebar)/application-edit/page.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/application-edit/page.tsx
@@ -2,7 +2,7 @@ import {AdminApplicationEditContainer} from '@/app/admin/(with-sidebar)/applicat
 
 export default function AdminApplicationEditPage() {
   return (
-    <section className='flex flex-col gap-6 p-20'>
+    <section className='flex flex-col gap-6 p-12.5'>
       <h1 className='text-h4'>모집 기간</h1>
       <AdminApplicationEditContainer />
     </section>

--- a/apps/recruit/src/app/admin/(with-sidebar)/applications/page.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/applications/page.tsx
@@ -3,7 +3,7 @@ import {SuspenseWrapper} from '@/components/wrappers/SuspenseWrapper';
 
 export default function AdminApplicationPage() {
   return (
-    <section className='flex flex-col p-20'>
+    <section className='flex flex-col p-12.5'>
       <div className='flex min-w-275 flex-col gap-13.25'>
         <h1 className='text-h4'>지원서 열람</h1>
         <SuspenseWrapper>

--- a/apps/recruit/src/app/admin/(with-sidebar)/recruitment/_components/RecruitmentContainer.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/recruitment/_components/RecruitmentContainer.tsx
@@ -22,7 +22,7 @@ export const RecruitmentContainer = () => {
   const isValidGeneration = Number.isFinite(generationId) && generationId > 0;
 
   return (
-    <div className='flex min-w-275 flex-col items-center justify-center gap-3.5 p-20 pt-17.25'>
+    <div className='flex min-w-275 flex-col items-center justify-center gap-3.5 p-12.5'>
       <AddGeneration />
       <ActiveRecruitment />
       {isValidGeneration && <ManageMail generationId={generationId} />}

--- a/apps/recruit/src/app/admin/(with-sidebar)/results/page.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/results/page.tsx
@@ -4,7 +4,7 @@ import {SuspenseWrapper} from '@/components/wrappers/SuspenseWrapper';
 
 export default function AdminResultsPage() {
   return (
-    <section className='flex min-w-275 flex-col items-center justify-center p-20'>
+    <section className='flex min-w-275 flex-col items-center justify-center p-12.5'>
       <RecruitmentInitializer>
         <SuspenseWrapper>
           <ResultsContainer />

--- a/apps/recruit/src/app/admin/_components/AdminSideBar.tsx
+++ b/apps/recruit/src/app/admin/_components/AdminSideBar.tsx
@@ -9,7 +9,7 @@ export const AdminSideBar = () => {
   const pathname = usePathname();
 
   return (
-    <nav className='sticky top-25 z-sidebar flex flex-col gap-7.5 px-6.25 py-12.5'>
+    <nav className='z-sidebar sticky top-30 flex flex-col gap-7.5 px-6.25'>
       <h2 className='text-h4 text-neutral-400'>관리자 페이지</h2>
       <ul className='flex w-50 flex-col gap-2.5'>
         {ADMIN_NAV_ITEMS.map(({label, href}) => {
@@ -21,7 +21,7 @@ export const AdminSideBar = () => {
                 href={href}
                 aria-current={isActive ? 'page' : undefined}
                 className={clsx(
-                  'block w-full rounded-[10px] px-2 py-2.5 text-h5 transition-colors',
+                  'text-h5 block w-full rounded-[10px] px-2 py-2.5 transition-colors',
                   isActive && 'bg-neutral-800 text-neutral-100'
                 )}>
                 {label}


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->
close #10 
<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->

2차 QA 테스트 결과 중 어드민 사이드바 포함 레이아웃 내부 메인 섹션의 패딩을 전체 조절했습니다.

기존 패딩 값이 너무 크다는 이야기가 있어서 `80px -> 50px` 로 조정!! 

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->
![Animation](https://github.com/user-attachments/assets/cc3452a1-5740-471c-b610-d4ba984c2dd1)

<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] UI 확인 플리즈