### PR TITLE
[FIX]: 어드민 메일 수정 버튼 관련 처리

### DIFF
--- a/apps/recruit/src/app/admin/(with-sidebar)/recruitment/_components/manage-mail/ManageMail.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/recruitment/_components/manage-mail/ManageMail.tsx
@@ -60,7 +60,7 @@ export const ManageMail = ({
   const canAccess = isGenerationExist || alwaysAble;
   const hasPermission = isRecruiting || alwaysAble;
 
-  const finalCanEdit = canAccess;
+  const finalCanEdit = canAccess && !isSent;
   const finalCanSend =
     canAccess && hasPermission && !isSent && waitingCount > 0;
 


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 --> 

close #9

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->

어드민에서 한번 보낸 메일은 다시 수정할 수 없게 되어있으므로(백엔드 로직) 이에 맞춰 isSent가 true인 메일의 경우 수정할 수 없게 수정 버튼을 disable 처리합니다.

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->

<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 수정 버튼 disable 됐는지 확인
