### PR TITLE
[FIX]: 지원서 생성(start) API 성공 시 응답 데이터(applicationId) 누락 현상

### DIFF
--- a/apps/recruit/src/services/api/apply/apply.api.ts
+++ b/apps/recruit/src/services/api/apply/apply.api.ts
@@ -68,20 +68,22 @@ export const startApplication = async (): Promise<StartApplicationResponse> => {
 
     // 파싱 실패 시
     // status 조회 API를 통해 applicationId 재확인 시도
-    const statusData = await getApplicationStatus();
-    if (statusData && statusData.applicationId) {
-      return {
-        applicationId: statusData.applicationId,
-        isSubmitted: statusData.isSubmitted ?? false,
-      };
+    try {
+      const statusData = await getApplicationStatus();
+      if (statusData?.applicationId) {
+        return {
+          applicationId: statusData.applicationId,
+          isSubmitted: statusData.isSubmitted ?? false,
+        };
+      }
+    } catch {
+      // status 조회도 실패하면 원래의 파싱 에러를 throw
     }
-
     throw parsed.error;
   } catch (error) {
     return handleApiError(error);
   }
 };
-
 /**
  * 기본 인적사항 조회
  */


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->
closed #39 
<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->
신규 유저가 처음 지원서를 생성할 때 발생하던 에러를 해결하고 안정성을 강화했습니다.

**문제 상황**: 서버에서 startApplication(POST) 호출 시 성공 응답(200 OK)은 오지만, 바디에 applicationId가 포함되지 않아 프론트엔드 파싱 과정에서 에러가 발생하고 플로우가 끊김

**해결 방법**: 응답 데이터 파싱 실패 시, 즉시 getApplicationStatus API를 호출하여 서버에 이미 생성된 지원서 ID를 직접 조회해오는 Fallback 로직을 추가함
<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->
![화면 기록 2026-02-08 오후 1 02 46](https://github.com/user-attachments/assets/136f4664-e836-49a9-827a-86247d08edd5)
완전 처음 접속하는 신규 유저입니다
<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 신규 계정으로 처음 로그인 시 '지원하기' 버튼 클릭 후 정상적으로 지원서 작성 페이지로 이동하는지 확인
- [ ] API 응답 데이터 누락 시에도 Fallback 로직 작동해 applicationId 정상적으로 가져오는지 확인
- [ ] 기존 지원서 있는 유저는 기존대로 잘 이동하는지 (start API 안 거침) 확인
