### PR TITLE
[FEAT]: 지원서 이탈 방지 훅 추가

### DIFF
--- a/apps/recruit/src/app/apply/_hooks/useApplyFormController.ts
+++ b/apps/recruit/src/app/apply/_hooks/useApplyFormController.ts
@@ -17,6 +17,7 @@ import {ROUTES} from '@/constants/routes';
 import {useApplyValidation} from './useApplyValidation';
 import {useApplySave} from './useApplySave';
 import {useApplyStepGuard} from './useApplyStepGuard';
+import {usePreventNavigation} from './usePreventNavigation';
 
 interface UseApplyFormControllerReturn {
   step: number;
@@ -95,6 +96,9 @@ export const useApplyFormController = (): UseApplyFormControllerReturn => {
 
   const {data: partQuestionsData, isFetched: isPartQuestionsFetched} =
     useGetPartQuestionsQuery(applicationId ? Number(applicationId) : null);
+
+  // 폼 수정 중 이탈 방지
+  usePreventNavigation(methods.formState.isDirty);
 
   // Step 건너뛰기 방지 가드 훅
   useApplyStepGuard({

--- a/apps/recruit/src/app/apply/_hooks/usePreventNavigation.ts
+++ b/apps/recruit/src/app/apply/_hooks/usePreventNavigation.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import {useEffect} from 'react';
+
+export const usePreventNavigation = (isDirty: boolean) => {
+  useEffect(() => {
+    if (!isDirty) return;
+
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = '';
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [isDirty]);
+};


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->
close #50 
<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->
**사용자 경험(UX) 개선 사항:**

* **`usePreventNavigation` Hook 추가**: 폼 수정 중(dirty 상태) 저장되지 않은 변경 사항이 있는지 감지하고, 브라우저 경고를 표시하여 의도치 않은 탐색을 방지하는 Hook을 신규 생성했습니다. (`apps/recruit/src/app/apply/_hooks/usePreventNavigation.ts`)
* **컨트롤러 통합**: `useApplyFormController`에 `usePreventNavigation` Hook을 통합하여, 폼이 수정된 상태일 때마다 탐색 방지 가드가 활성화되도록 설정했습니다. (`apps/recruit/src/app/apply/_hooks/useApplyFormController.ts`)

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->
![화면 기록 2026-02-09 오후 5 55 34](https://github.com/user-attachments/assets/da9b0cb9-e392-4f74-b136-4b89fd3f119b)

<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 작성 도중 새로고침 시 창 뜨는 것 확인