### PR TITLE
[UI]: 온보딩 뷰포트 크기 자동화 대응 

### DIFF
--- a/apps/homepage/src/app/onboarding/_containers/OnboardingContainer.tsx
+++ b/apps/homepage/src/app/onboarding/_containers/OnboardingContainer.tsx
@@ -38,7 +38,7 @@ export const OnboardingContainer = () => {
   });
   const currentConfig = STEP_CONFIG[funnel.step];
   return (
-    <div className='custom-scrollbar flex max-h-209.25 min-h-164 w-134.75 flex-col gap-11.75 overflow-y-scroll rounded-[40px] bg-neutral-100/30 px-11 py-18.5'>
+    <div className='custom-scrollbar flex h-fit max-h-[90vh] w-134.75 flex-col gap-11.75 overflow-y-auto rounded-[40px] bg-neutral-100/30 px-11 py-18.5'>
       <div className='flex flex-col gap-4'>
         <div className='flex flex-row justify-between'>
           <h2 className='flex flex-row items-center gap-3.5'>

--- a/apps/homepage/src/app/onboarding/page.tsx
+++ b/apps/homepage/src/app/onboarding/page.tsx
@@ -7,7 +7,7 @@ export default function OnboardingPage() {
     <section className='relative h-screen w-full overflow-hidden bg-black'>
       <OnboardingBackground className='absolute inset-0 h-full w-full object-cover' />
 
-      <div className='relative flex h-full w-full items-start px-30 py-10'>
+      <div className='relative flex h-full w-full items-center px-30 py-10'>
         <div className='absolute top-2/5 left-1/4 -translate-x-1/2'>
           <CotatoLogo />
         </div>


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->
close #69 
<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->

온보딩 컨테이너에서 기존 픽셀로 고정되어 있던 height 크기를 뷰포트 기준 자동화, 스크롤을 auto로 설정하여 일정 이상 height에 대해서만 스크롤바가 보이게 변경했습니다 


컨테이너 또한 뷰포트 세로 기준 가운데에 위치하게 변경했습니다 

해당 화면 모두 컨펌 완입니당 (피그마 디자인과 살짝 다른 부분이 있어 컨펌받은 상태)

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 변경 UI 확인 부탁 각자 화면에서 괜찮은지!!!
