### PR TITLE
[FIX]: 메일 전송 중 로직을 성공실패 합이 0일 때로 수정 

### DIFF
--- a/apps/recruit/src/hooks/useManageMail.ts
+++ b/apps/recruit/src/hooks/useManageMail.ts
@@ -50,11 +50,11 @@ export const useManageMail = (generationId: number, mailType: string) => {
     setIsManualRefreshing(false);
   }, [refetch]);
 
-  // 전송 중 (성공 + 실패 합이 전체 대상자 수보다 적을 때)
+  // 전송 중 (성공 + 실패 합이 0일 때)
   const isCurrentlyProcessing =
     isMutationSending ||
     isManualRefreshing ||
-    (data?.isSent && data.successCount + data.failCount < totalTargetCount) ||
+    (data?.isSent && data.successCount + data.failCount === 0) ||
     (isFetching && !data?.isSent);
 
   const handleSendClick = () => {


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->
close #83

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->

메일 전송 중 로직을 성공실패 합이 0일 때로 수정했습니다! 
기존엔 리프레시 버튼 뜨는(전송 중) 로직을 successCount+failCount<totalCount일 때로 해두었었는데 successCount+failCount===0일 때 전송중으로 판단하도록 수정했습니다. 이유는 만약에 서버 내에서 전송 오류가 나서 전체 대상자는 7명인데 성공 6, 실패 0 이런 경우로 오게되면 실제로는 전송이 모두 완료됐음에도 그 카운트 차이 때문에 계속 전송 중이라고 버튼이 뜰 문제가 있어서 그냥 0,0만 아니면 전송은 완료된 것으로 판단하도록 하려고 수정했습니다.

### 참고
기획에서 지원알림메일 보낼 때에도 리프레시 버튼 뜨게해주라고했는데 이미 그렇게 뜨고있어서(...) 걍 그건 이미 구현되어있다고 봐주시면 될 듯.

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->

<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 바뀐 리프레시(전송 중) 로직 확인
