### PR TITLE
[FEAT]: 리쿠르트 모집 공고 카운트다운 API 연동

### DIFF
--- a/apps/recruit/src/components/layout/CountdownTimer.tsx
+++ b/apps/recruit/src/components/layout/CountdownTimer.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import {useRecruitmentNoticeQuery} from '@/hooks/queries/useRecruitmentNotice.query';
+import {Spinner} from '@repo/ui/components/spinner/Spinner';
 import clsx from 'clsx';
-import {useState, useEffect, useMemo} from 'react';
+import {useState, useEffect} from 'react';
 
 interface CountdownTimerProps {
   highlightUnits?: boolean;
@@ -12,53 +14,65 @@ const calculateTimeLeft = (targetTimestamp: number) => {
   const difference = targetTimestamp - now;
 
   if (difference <= 0) {
-    return {h: '00', m: '00', s: '00'};
+    return {d: '0', h: '0', m: '0', s: '0'};
   }
 
-  const hours = Math.floor(difference / (1000 * 60 * 60));
+  const days = Math.floor(difference / (1000 * 60 * 60 * 24));
+  const hours = Math.floor(
+    (difference % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)
+  );
   const minutes = Math.floor((difference % (1000 * 60 * 60)) / (1000 * 60));
   const seconds = Math.floor((difference % (1000 * 60)) / 1000);
 
   return {
-    h: String(hours).padStart(2, '0'),
-    m: String(minutes).padStart(2, '0'),
-    s: String(seconds).padStart(2, '0'),
+    d: String(days),
+    h: String(hours),
+    m: String(minutes),
+    s: String(seconds),
   };
 };
 
 export default function CountdownTimer({
   highlightUnits = false,
 }: CountdownTimerProps) {
-  // 서버/첫 렌더에서도 항상 동일한 값
-  const [timeLeft, setTimeLeft] = useState<{h: string; m: string; s: string}>(
-    () => ({h: '00', m: '00', s: '00'})
-  );
-
-  // 목표 시간 (추후 API 연동 가능)
-  const targetDate = useMemo(
-    () => new Date('2026-03-01T00:00:00').getTime(),
-    []
-  );
+  const {data: noticeData, isLoading} = useRecruitmentNoticeQuery();
+  const [timeLeft, setTimeLeft] = useState(() => ({
+    d: '0',
+    h: '0',
+    m: '0',
+    s: '0',
+  }));
 
   useEffect(() => {
+    if (!noticeData?.endDate) return;
+
+    const targetDate = new Date(noticeData.endDate).getTime();
+
     const tick = () => {
       setTimeLeft(calculateTimeLeft(targetDate));
     };
 
-    // 첫 업데이트는 브라우저 페인트 이후에 실행
-    const rafId = requestAnimationFrame(tick);
+    tick();
     const timerId = setInterval(tick, 1000);
 
-    return () => {
-      cancelAnimationFrame(rafId);
-      clearInterval(timerId);
-    };
-  }, [targetDate]);
+    return () => clearInterval(timerId);
+  }, [noticeData]);
 
   const textColor = highlightUnits ? 'text-primary' : 'text-neutral-400';
 
+  if (isLoading) return <Spinner />;
+
   return (
     <div className='flex items-end gap-10'>
+      <div className='flex flex-col'>
+        <p className={clsx(textColor, 'text-body-l-sb text-center')}>DAY</p>
+        <span className='text-h1 text-center text-neutral-400'>
+          {timeLeft.d}일
+        </span>
+      </div>
+
+      <span className='text-h1 text-center text-neutral-400'>:</span>
+
       <div className='flex flex-col'>
         <p className={clsx(textColor, 'text-body-l-sb text-center')}>HOUR</p>
         <span className='text-h1 text-center text-neutral-400'>


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->

close #101 

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->

### 모집 공고 카운트다운 타이머 연동
`RecruitmentLayout.tsx` 내부에서 쓰이는 `CountdownTimer.tsx` 부분의 API를 연동했습니다.

endDate를 기준으로, 현재 시간과 endDate의 차이를 렌더링합니다.

### DAY : HOUR : MINUTE : SECOND 포맷으로 변경
기존 시간:분:초 포맷에서 일자를 포함한 타이머로 변경했습니다. 
관련 부분 작업하면서 padStart로 1일 -> 01일 로 표현되던 문제가 있어 padStart 로직을 제거해 두었습니다. 

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->
<img width="818" height="488" alt="image" src="https://github.com/user-attachments/assets/3bc9c68d-7a43-4e14-a0cf-2dd74b746ea5" />

<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] UI 확인, 카운트다운 로직 확인 
