### PR TITLE
[FEAT]: 헤더의 출석하기 버튼 출석하기 페이지로 라우팅

### DIFF
--- a/apps/homepage/src/components/layout/Header.tsx
+++ b/apps/homepage/src/components/layout/Header.tsx
@@ -81,7 +81,7 @@ export const Header = () => {
 
                 {/* 출석 활성화 시간일 때  */}
                 <Link
-                  href={'#'}
+                  href={ROUTES.MYPAGE_ATTENDANCE}
                   className='border-primary text-body-l-sb bg-primary/30 rounded-[10px] border px-6 py-1.5 text-white'>
                   출석하기
                 </Link>


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->

close #106

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->

헤더의 출석하기 버튼을 클릭하면 실제 출석하기 페이지로 이동하도록 라우팅해두었습니다!
매우 간단한 작업이라 바로 머지하겠습니다 (_ _)

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->

<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 헤더 출석하기 라우팅