### PR TITLE
[FIX]: 리크루트 어드민 헤더 높이 문제 수정

### DIFF
--- a/apps/recruit/src/components/layout/Header.tsx
+++ b/apps/recruit/src/components/layout/Header.tsx
@@ -68,7 +68,7 @@ export const Header = () => {
     <>
       <header
         style={{height: `${HEADER_HEIGHT}px`}}
-        className='z-header sticky top-0 flex w-full min-w-360 items-center justify-between bg-black pr-26.25 pl-6.25'>
+        className='z-header sticky top-0 flex w-full min-w-360 shrink-0 items-center justify-between bg-black pr-26.25 pl-6.25'>
         <div>
           <Link href={ROUTES.HOME}>
             <MainLogo className='w-36.5' />


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->

close #131

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->

리크루트의 헤더가 어드민 페이지에 가면 기존에 상수로 정의해둔 88px가 적용되지않고 70px로 적용되는 문제를 해결했습니다.
(`shrink-0` 적용)

+) 커밋 스코프 recruit로 작성한다는걸 homepage로 잘못 작성했네요 죄송합니다^^..
+) 바로 머지하겠습니다.

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->

<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 리크루트 어드민 헤더 높이 88px인지 확인
