### PR TITLE
[FIX]: 프로젝트 등록/수정 오류 수정

### DIFF
--- a/apps/homepage/src/app/(with-header)/(with-footer)/project/add-project/_components/ImageUploadField.tsx
+++ b/apps/homepage/src/app/(with-header)/(with-footer)/project/add-project/_components/ImageUploadField.tsx
@@ -47,6 +47,7 @@ export const ImageUploadField = ({
       <div className='flex flex-col gap-4.75'>
         <ImagePreviewer selectedImage={selectedImage} onRemove={handleRemove} />
         <FullButton
+          type='button'
           label='이미지 업로드'
           labelTypo='body_l_sb'
           height={46}


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->

close #151

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->
## 프로젝트 이미지 등록 시 바로 등록/수정 API 호출되던 오류 수정
ImageUploadField 내 type button 명시적 추가를 통한 form 내부 button의 자동 submit 처리를 수정해서 오류를 해결했습니다.

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->

<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 프로젝트 오류 해결