### PR TITLE
[FIX]: 모바일 접속 유도 가이드 레이아웃이 깨지는 문제

### DIFF
--- a/packages/ui/src/components/overlay/MobileBlockOverlay.tsx
+++ b/packages/ui/src/components/overlay/MobileBlockOverlay.tsx
@@ -12,7 +12,7 @@ export const MobileBlockOverlay = ({title}: MobileBlockOverlayProps) => {
 
   useEffect(() => {
     const checkMobile = () => {
-      setIsMobile(window.innerWidth < 720);
+      setIsMobile(window.innerWidth < 1024);
     };
 
     checkMobile();
@@ -27,7 +27,7 @@ export const MobileBlockOverlay = ({title}: MobileBlockOverlayProps) => {
       role='dialog'
       aria-modal='true'
       aria-labelledby='mobile-block-title'
-      className={`... ${isMobile === null ? 'hidden max-[720px]:flex min-[720px]:hidden' : ''}`}>
+      className={`fixed inset-0 z-104 flex flex-col items-center justify-center bg-black p-10 text-center ${isMobile === null ? 'hidden max-lg:flex lg:hidden' : ''}`}>
       <CotatoLogo />
       <div className='mt-20 flex flex-col gap-10'>
         <h1 id='mobile-block-title' className='text-h2 font-bold text-white'>


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->
close #158 

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->

모바일 접속 유도 오버레이가 깨지는 문제가 있어서 수정했습니다.
기존 fixed 로 설정했던 스타일이 빠져 있어 걸어두고 기존 1024px로 일단 원복해 뒀어요


<br><br>