### PR TITLE
[FIX]: sessionNumber를 title로 표시되도록 수정

### DIFF
--- a/apps/homepage/src/app/(with-header)/mypage/attendance/_components/SessionCard.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/attendance/_components/SessionCard.tsx
@@ -63,7 +63,7 @@ export const SessionCard = ({
             {session.sessionDateTime.split('T')[0].replaceAll('-', '.')}
           </span>
           <h3 className='text-h3 text-neutral-800'>
-            {session.sessionNumber}회차 세션
+            {session.title}
           </h3>
         </div>
         <div


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->

close #172

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->

기존에 출석하기 페이지에서 `sessionNumber`로 렌더링하던 부분을 `title`로 렌더링되도록 수정했습니다

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->

<img width="1512" height="982" alt="스크린샷 2026-02-20 오후 6 18 41" src="https://github.com/user-attachments/assets/1c3dbc58-5238-457c-a41e-2e522ee2643f" />

<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 출석하기 title 렌더링 확인
