### PR TITLE
[FEAT]: 어드민 지원서 상세 페이지 지원자 이름 기반 동적 메타데이터 적용

### DIFF
--- a/apps/recruit/src/app/admin/(no-sidebar)/applications/[id]/_containers/AdminApplicationContainer.tsx
+++ b/apps/recruit/src/app/admin/(no-sidebar)/applications/[id]/_containers/AdminApplicationContainer.tsx
@@ -14,6 +14,7 @@ import {APPLICATIONS_PART_TABS} from '@/constants/admin/admin-applications';
 import {BasicInfoView} from '@/components/application/BasicInfoView';
 import {PartQuestionView} from '@/components/application/PartQuestionView';
 import {EtcQuestionView} from '@/components/application/EtcQuestionView';
+import {useEffect} from 'react';
 
 export const AdminApplicationContainer = () => {
   const searchParams = useSearchParams();
@@ -32,6 +33,13 @@ export const AdminApplicationContainer = () => {
 
   const rawStep = Number(searchParams.get('step') ?? 1);
   const step = Math.min(Math.max(rawStep, 1), 3);
+
+  useEffect(() => {
+    const applicantName = basicInfo?.data?.name;
+    if (applicantName) {
+      document.title = `${applicantName} 지원서`;
+    }
+  }, [basicInfo?.data?.name, step]);
 
   const handleNext = () => {
     if (step < 3) {


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->
close #193 
<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->

지원서 상세 페이지 진입 및 단계(Step 1~3) 이동 시, 브라우저 탭 제목에 지원자 이름을 표시하여 관리자 작업의 편의성을 개선했습니다.

현재 인증 토큰을 로컬 스토리지에서 관리하고 있어 서버 컴포넌트에서 API 호출이 불가능한 관계로 `AdminApplicationContainer.tsx` 컴포넌트에서 useEffect를 활용해 클라이언트 사이드에서 document.title을 동적으로 조작합니다. (때문에 첫 마운트 시 기본 타이틀 보임, 후에 타이틀 변경) 

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->

<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 상세 페이지 진입 시 지원자 이름이 포함된 타이틀(OOO 지원서)이 정상적으로 표시되는지 확인
- [ ] 하단 다음/이전 버튼 클릭으로 step 이동 시에도 타이틀 초기화되지 않고 유지되는지 확인 
