### PR TITLE
[FIX]: URL 파라미터(evaluator) 주입 시 브라우저 타이틀 초기화 현상 수정

### DIFF
--- a/apps/recruit/src/app/admin/(no-sidebar)/applications/[id]/_containers/AdminApplicationContainer.tsx
+++ b/apps/recruit/src/app/admin/(no-sidebar)/applications/[id]/_containers/AdminApplicationContainer.tsx
@@ -33,13 +33,14 @@ export const AdminApplicationContainer = () => {
 
   const rawStep = Number(searchParams.get('step') ?? 1);
   const step = Math.min(Math.max(rawStep, 1), 3);
+  const evaluator = searchParams.get('evaluator');
 
   useEffect(() => {
     const applicantName = basicInfo?.data?.name;
     if (applicantName) {
       document.title = `${applicantName} 지원서`;
     }
-  }, [basicInfo?.data?.name, step]);
+  }, [basicInfo?.data?.name, step, evaluator]);
 
   const handleNext = () => {
     if (step < 3) {


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->

close #196 

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->

지원서 상세 페이지 진입 및 단계 이동 시, 브라우저 탭 제목(Metadata)이 초기화되는 버그를 수정하고 지원자 이름을 동적으로 표시하도록 개선했습니다.

### 문제 원인 

AdminApplicationEvaluationContainer에서 초기 진입 시 evaluator 파라미터를 URL에 강제 주입(router.replace)하는데, 이 과정에서 발생하는 리렌더링이 브라우저 타이틀을 시스템 기본값(cotato | recruit)으로 덮어쓰는 현상을 확인했습니다.

### 해결 방법 

URL 파라미터(step, evaluator)가 변경될 때마다 타이틀을 재선언하도록 의존성 배열을 보강하여, 어떤 상황에서도 지원자 이름이 탭 제목에 유지되도록 조치했습니다.


## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 상세 페이지 최초 진입 시 지원자 성함이 포함된 타이틀([이름] 지원서)이 정상적으로 노출되는지 확인
