### PR TITLE
[FIX]: 프로젝트 관련 design ENUM을 DESIGN에서 DE로 수정

### DIFF
--- a/apps/homepage/src/app/(with-header)/(with-footer)/project/[projectId]/_hooks/useProjectDetail.ts
+++ b/apps/homepage/src/app/(with-header)/(with-footer)/project/[projectId]/_hooks/useProjectDetail.ts
@@ -33,7 +33,7 @@ export const useProjectDetail = (projectId: number) => {
   const groupedMembers = useMemo(() => {
     const initialGroups: Record<Position, string[]> = {
       PM: [],
-      DESIGN: [],
+      DE: [],
       FE: [],
       BE: [],
     };
@@ -46,7 +46,7 @@ export const useProjectDetail = (projectId: number) => {
     }, initialGroups);
   }, [mappedData]);
 
-  const positions: Position[] = ['PM', 'DESIGN', 'FE', 'BE'];
+  const positions: Position[] = ['PM', 'DE', 'FE', 'BE'];
 
   return {
     data: mappedData,

--- a/apps/homepage/src/app/(with-header)/(with-footer)/project/add-project/_components/AddProjectForm.tsx
+++ b/apps/homepage/src/app/(with-header)/(with-footer)/project/add-project/_components/AddProjectForm.tsx
@@ -42,7 +42,7 @@ export const AddProjectForm = ({
   const formatInitialMembers = (
     members: {name: string; position: Position}[] | undefined
   ): TeamState => {
-    const result: TeamState = {PM: [], DESIGN: [], FE: [], BE: []};
+    const result: TeamState = {PM: [], DE: [], FE: [], BE: []};
     if (!members) return result;
     members.forEach((m) => {
       if (result[m.position]) result[m.position].push(m.name);
@@ -54,7 +54,7 @@ export const AddProjectForm = ({
     useTeamMembers(
       initialData?.memberInfos
         ? formatInitialMembers(initialData.memberInfos)
-        : {PM: ['감직이'], DESIGN: ['감직이'], FE: ['감직이'], BE: ['감직이']}
+        : {PM: ['감직이'], DE: ['감직이'], FE: ['감직이'], BE: ['감직이']}
     );
 
   const {states, setters, isFormValid} = useProjectForm(

--- a/apps/homepage/src/app/(with-header)/(with-footer)/project/add-project/_components/TeamSection.tsx
+++ b/apps/homepage/src/app/(with-header)/(with-footer)/project/add-project/_components/TeamSection.tsx
@@ -4,7 +4,7 @@ import Plus from '@repo/ui/assets/icons/plus-nobackground.svg';
 import {TeamSectionProps} from '@/schemas/project/project-type';
 import {POSITION_LABEL} from '@/constants/project/project-detail';
 
-const ROLES: Position[] = ['PM', 'DESIGN', 'FE', 'BE'];
+const ROLES: Position[] = ['PM', 'DE', 'FE', 'BE'];
 
 export const TeamSection = ({
   teamMembers,

--- a/apps/homepage/src/constants/project/project-detail.ts
+++ b/apps/homepage/src/constants/project/project-detail.ts
@@ -1,6 +1,6 @@
 export const POSITION_LABEL = {
   PM: 'PM',
-  DESIGN: 'DE',
+  DE: 'DE',
   FE: 'FE',
   BE: 'BE',
 } as const;

--- a/apps/homepage/src/schemas/project/project.schema.ts
+++ b/apps/homepage/src/schemas/project/project.schema.ts
@@ -1,6 +1,6 @@
 import {z} from 'zod';
 
-export const PositionEnum = z.enum(['PM', 'DESIGN', 'FE', 'BE']);
+export const PositionEnum = z.enum(['PM', 'DE', 'FE', 'BE']);
 
 export const ProjectRegistrationSchema = z.object({
   generationId: z.number().int(),


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->

close #233


<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->

## 프로젝트 디자인 ENUM DESIGN ➡️ DE로 수정
프로젝트 상세조회 응답에서의 position ENUM을 변경된 스키마에 맞춰 DE로 수정했습니다.
추가로 프로젝트 등록/수정 시 position도 DE로 보내도록 함께 수정했습니다.

### +) 기존의 `POSITION_LABEL` 구조를 유지하기로 한 이유
Design ENUM의 수정으로 이제 Position 타입(PM, DE, FE, BE)과 실제 화면에 노출되는 텍스트가 일치하지만, 

1. 향후 노출 라벨명이 또 어떻게 변경될 지 모르기 때문에, 변경될 경우 비즈니스 로직을 건드리지 않고 지금의 경우처럼 상수만 수정하여 UI를 대응하는 쪽이 좋다고 판단
2.  텍스트가 겹치더라도 데이터와 표시 방식을 분리하는 것이 유지보수 측면에서 더 안전하다고 판단

의 이유로 기존처럼 `POSITION_LABEL`을 유지하는 것으로 결정했어요!

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->

<img width="1624" height="970" alt="스크린샷 2026-03-03 오후 8 36 43" src="https://github.com/user-attachments/assets/6a5c0450-d1e7-4e56-88cd-67b6687e6b24" />

<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 프로젝트 상세조회 DE 잘 되는지 확인
- [ ] 프로젝트 등록/수정 DE 잘 올라가는지 확인
- [ ] 프로젝트 design ENUM 변경 확인 (DESIGN -> DE)
