### PR TITLE
[FIX]: 마이페이지 출석하기 버튼 관련 QA 수정사항 반영

### DIFF
--- a/apps/homepage/src/app/(with-header)/mypage/attendance/_components/SessionCard.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/attendance/_components/SessionCard.tsx
@@ -34,17 +34,24 @@ export const SessionCard = ({
     [session.imageUrls]
   );
 
-  const {isCompleted, isAvailable} = useMemo(() => {
-    // NOT_YET이 아니고 실제 결과 값이 있을 때만 완료
+  const {isCompleted, showAttendanceButton, isButtonActive} = useMemo(() => {
+    // NOT_YET이 아니고 실제 결과 값이 있을 때
     const hasFinalResult =
-      !!session.myAttendanceResult && session.myAttendanceResult !== 'NOT_YET';
+      session.myAttendanceResult && session.myAttendanceResult !== 'NOT_YET';
+
+    const status = session.attendanceStatus;
+
+    // OPEN, LATE일 때만 출석하기 가능
+    const canAttend = status === 'OPEN' || status === 'LATE';
+
+    // 출석하기 버튼 렌더링 여부
+    const shouldShowButton =
+      !hasFinalResult && (status === 'BEFORE' || canAttend);
 
     return {
       isCompleted: hasFinalResult,
-      isAvailable:
-        !hasFinalResult &&
-        (session.attendanceStatus === 'OPEN' ||
-          session.attendanceStatus === 'LATE'),
+      showAttendanceButton: shouldShowButton,
+      isButtonActive: canAttend, // false면 disabled
     };
   }, [session.myAttendanceResult, session.attendanceStatus]);
 
@@ -87,10 +94,16 @@ export const SessionCard = ({
               }
             </div>
           ) : (
-            isAvailable && (
+            showAttendanceButton && (
               <button
-                onClick={onAttendance}
-                className='bg-primary text-body-m-sb shadow-default flex h-8 w-29 items-center justify-center rounded-[10px] font-semibold text-white'>
+                onClick={isButtonActive ? onAttendance : undefined}
+                disabled={!isButtonActive}
+                className={clsx(
+                  'text-body-m-sb shadow-default flex h-8 w-29 items-center justify-center rounded-[10px] text-white transition-all',
+                  isButtonActive
+                    ? 'bg-primary cursor-pointer'
+                    : 'bg-text-disabled cursor-default'
+                )}>
                 출석하기
               </button>
             )


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->

close #240

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->

## 출석시간 전 출석하기 버튼 disabled 처리
마이페이지 QA 수정사항을 반영해 출석시간 전에도 세션 목록에서 출석하기 버튼이 뜨도록 변경했습니다.
대신 이때는 disabled 상태로 렌더링됩니다. (`bg-text-disabled`)

| 내 출석 결과 (`myAttendanceResult`) | 세션 상태 (`attendanceStatus`) | 렌더링 요소 |  렌더링 내용 |
| :--- | :--- | :--- | :--- |
| **출석 결과가 존재** (PRESENT, LATE, ABSENT 등) | 상관 없음 | **결과 라벨** | 세션 종료 여부와 무관하게 결과 상시 렌더링 |
| **NOT_YET**  | **BEFORE** | **출석 버튼** | 출석 시작 전 상태로 disabled 출석버튼 렌더링 |
| **NOT_YET** | **OPEN / LATE** | **출석 버튼** | 출석 가능 상태로 활성화된 버튼 렌더링 |
| **NOT_YET** | **CLOSED** | **라벨, 버튼 모두 노출 X** | 출석 미참여 상태로 마감 |

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->

| 출석 시작 전 | 출석 가능 (OPEN, LATE) | 출석 완료 |
| :---: | :---: | :---: |
| <img src="https://github.com/user-attachments/assets/3bc15cd8-649f-4a41-9e08-a945338020c3" width="300" /> | <img src="https://github.com/user-attachments/assets/b578ee85-1ebf-4a64-a70a-54ea18d6398d" width="300" /> | <img src="https://github.com/user-attachments/assets/818d0508-05e3-4605-a22c-fc5313508e15" width="300" /> |

| 지각  | 결석 |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/bace854d-11f5-4eb3-afb6-e164a1c4b79a" width="450" /> | <img src="https://github.com/user-attachments/assets/06656b24-d4ea-4eb6-8877-c659d002beab" width="450" /> |


<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [x] 출석 시작 전에 출석하기 버튼 disabled 뜨는지 확인
