### PR TITLE
[FIX]: 마이페이지 드롭다운 순서 관련 QA 수정사항 반영

### DIFF
--- a/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_containers/DropdownContainer.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_containers/DropdownContainer.tsx
@@ -26,16 +26,16 @@ export const DropdownContainer = () => {
   const generations = useMemo(() => {
     if (!generationList) return [];
     return [...generationList]
-      .sort((a, b) => a.generationId - b.generationId)
+      .sort((a, b) => b.generationId - a.generationId)
       .map((item) => `${item.generationId}기`);
   }, [generationList]);
 
   const sessions = useMemo(() => {
     if (!sessionList) return [];
     return [...sessionList]
-      .sort((a, b) => a.sessionId - b.sessionId)
+      .sort((a, b) => b.sessionId - a.sessionId)
       .map((item, idx) => ({
-        sessionOption: `${idx + 1}회차 세션`,
+        sessionOption: `${sessionList.length - idx}회차 세션`,
         attendanceId: item.attendanceId,
       }));
   }, [sessionList]);

--- a/apps/homepage/src/app/(with-header)/mypage/admin/penalties/_containers/DropdownContainer.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/penalties/_containers/DropdownContainer.tsx
@@ -35,16 +35,16 @@ export const DropdownContainer = () => {
   const generations = useMemo(() => {
     if (!generationList) return [];
     return [...generationList]
-      .sort((a, b) => a.generationId - b.generationId)
+      .sort((a, b) => b.generationId - a.generationId)
       .map((item) => `${item.generationId}기`);
   }, [generationList]);
 
   const sessions = useMemo(() => {
     if (!sessionList) return [];
     return [...sessionList]
-      .sort((a, b) => a.sessionId - b.sessionId)
+      .sort((a, b) => b.sessionId - a.sessionId)
       .map((item, idx) => ({
-        sessionOption: `${idx + 1}회차 세션`,
+        sessionOption: `${sessionList.length - idx}회차 세션`,
         sessionId: item.sessionId,
       }));
   }, [sessionList]);


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->

#243 

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->

마이페이지 '출석 관리 페이지'와 '상벌점 관리 페이지'에서 기수와 세션을 선택하는 드롭다운 옵션을 내림차순(ex. 13->8)으로 변경합니다.

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->

### 기존 오름차순

| 기수 선택 | 세션 선택 |
| :---: | :---: |
| <img width="172" height="167" alt="image" src="https://github.com/user-attachments/assets/3b442e79-5596-419d-9f3a-9957154c38a2" /> | <img width="167" height="146" alt="image" src="https://github.com/user-attachments/assets/1408dabd-4f6e-4fb2-9da6-3514010f3152" /> |

### 변경된 내림차순

| 기수 선택 | 세션 선택 |
| :---: | :---: |
| <img width="168" height="167" alt="image" src="https://github.com/user-attachments/assets/a64c0e12-0362-4f7b-bed8-b507539f5687" /> | <img width="164" height="121" alt="image" src="https://github.com/user-attachments/assets/eaf58208-744b-4d93-91b5-5a9ed6cc0ca9" /> |

<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 마이페이지의 '출석 관리 페이지'와 '상벌점 관리 페이지'의 기수 및 세션 선택 옵션의 순서가 내림차순인지 확인
- [ ] 해당 기수의 정보가 제대로 출력되고 있는지 확인 (드롭다운은 3회차를 선택했는데, 실제로 렌더링 되는 데이터가 1회차이지는 않은지)
