### PR TITLE
[FIX]: 마이페이지 나의활동 상벌점 현황 key 관련 버그 수정

### DIFF
--- a/apps/homepage/src/app/(with-header)/mypage/activity/_components/PenaltyRow.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/activity/_components/PenaltyRow.tsx
@@ -2,34 +2,40 @@ import {POINT_STATUS} from '@/constants/mypage-mem/mypage-activity';
 import {PenaltyRecord} from '@/schemas/mypage-mem/activity/penalty.schema';
 import clsx from 'clsx';
 
-export const PenaltyRows = ({data}: {data: PenaltyRecord[]}) => (
-  <>
-    {data.map((record) => {
-      const status = POINT_STATUS[
-        record.pointType as keyof typeof POINT_STATUS
-      ] ?? {
-        label: record.pointType,
-        className: 'bg-neutral-400',
-      };
-      return (
-        <tr key={record.sessionId} className='h-12.25 text-center'>
-          <td>{record.week + 1}</td>
-          <td>{record.content}</td>
-          <td className='flex h-12.25 items-center justify-center py-[8.5px]'>
-            <span
-              className={clsx(
-                'text-body-m-sb flex h-full w-18.75 items-center justify-center rounded-[10px] text-white',
-                status?.className
-              )}>
-              {status?.label}
-            </span>
-          </td>
-          <td>{record.point}점</td>
-          <td className='text-body-l text-neutral-800'>
-            {record.cumulativePoint}
-          </td>
-        </tr>
-      );
-    })}
-  </>
-);
+export const PenaltyRows = ({data}: {data: PenaltyRecord[]}) => {
+  const sortedData = [...data].sort((a, b) => b.week - a.week);
+  return (
+    <>
+      {sortedData.map((record, index) => {
+        const status = POINT_STATUS[
+          record.pointType as keyof typeof POINT_STATUS
+        ] ?? {
+          label: record.pointType,
+          className: 'bg-neutral-400',
+        };
+
+        return (
+          <tr
+            key={`${record.sessionId}-${index}`}
+            className='h-12.25 text-center'>
+            <td>{record.week + 1}</td>
+            <td>{record.content}</td>
+            <td className='flex h-12.25 items-center justify-center py-[8.5px]'>
+              <span
+                className={clsx(
+                  'text-body-m-sb flex h-full w-18.75 items-center justify-center rounded-[10px] text-white',
+                  status?.className
+                )}>
+                {status?.label}
+              </span>
+            </td>
+            <td>{record.point}점</td>
+            <td className='text-body-l text-neutral-800'>
+              {record.cumulativePoint}
+            </td>
+          </tr>
+        );
+      })}
+    </>
+  );
+};


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->

close #248

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->

## 마이페이지 - 나의활동 상벌점 현황 key 버그 수정
마이페이지 나의 활동 상벌점 현황 세션별 조회 부분에서 같은 회차 내에서 매핑되는 (=sessionId가 동일할 경우) 내용이 두개 이상 있을 경우 발생했던 map key 중복 오류를 수정했습니다.
<br>

### 문제 상황

<img width="1624" height="973" alt="스크린샷 2026-03-06 오후 6 02 50" src="https://github.com/user-attachments/assets/92b91bcc-fcda-47f5-8f67-0a322129dc11" />

- 3회차 세션 지각
- 3회차 비어네트워킹 3회 참여

와 같이 같은 회차 내에 두개 이상의 내역이 조회될 경우 발생하던 오류입니다!
<br>

### 문제 원인
저런 경우가 있을 거라고 생각을 못했어서 data map의 key를 `key={record.sessionId}` 로 했었는데 여기서 key 중복 문제가 발생했습니다.


<br>

### 문제 해결
key를 unique하게 유지하기 위해 `key={${record.sessionId}-${index}}` 로 변경했습니다.
다만 이렇게 하면 최신 회차가 위로 오게 정렬이 안되는 문제가 있어서 data를 먼저 `[...data].sort((a, b) => b.week - a.week)`로 정렬하는 방식으로 수정했습니다.

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->

<img width="1624" height="973" alt="스크린샷 2026-03-06 오후 6 10 41" src="https://github.com/user-attachments/assets/433e49f1-fb53-46ed-b1f6-192f17297cd3" />

이제 이런 식으로 잘 렌더링 됩니다.

<br><br>



## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 변경된 key 확인 (key 중복 문제 발생안하는거 확인)
