### PR TITLE
[FIX]: 세션 드롭다운 렌더링 순서 오류

### DIFF
--- a/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_containers/DropdownContainer.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_containers/DropdownContainer.tsx
@@ -33,7 +33,7 @@ export const DropdownContainer = () => {
   const sessions = useMemo(() => {
     if (!sessionList) return [];
     return [...sessionList]
-      .sort((a, b) => b.sessionId - a.sessionId)
+      .sort((a, b) => a.sessionId - b.sessionId)
       .map((item, idx) => ({
         sessionOption: `${sessionList.length - idx}회차 세션`,
         attendanceId: item.attendanceId,

--- a/apps/homepage/src/app/(with-header)/mypage/admin/penalties/_containers/DropdownContainer.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/penalties/_containers/DropdownContainer.tsx
@@ -42,7 +42,7 @@ export const DropdownContainer = () => {
   const sessions = useMemo(() => {
     if (!sessionList) return [];
     return [...sessionList]
-      .sort((a, b) => b.sessionId - a.sessionId)
+      .sort((a, b) => a.sessionId - b.sessionId)
       .map((item, idx) => ({
         sessionOption: `${sessionList.length - idx}회차 세션`,
         sessionId: item.sessionId,


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->

#252 

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->

출석 관리, 상벌점 관리 페이지의 세션 드롭다운에서 오름차순으로 작성되어있는 것이, 실제로는 내림차순, 즉 실제 sessionId가 반대로 렌더링된 오류를 해결했습니다.

<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 출석 관리와 상벌점 관리에서 특정 세션을 선택하고 반영한 변경사항이 나의 활동 페이지에서 같은 회차 세션의 정보로 잘 들어갔는지 확인
