### PR TITLE
[FIX]: 출석 상태가 OPEN일 때 플로팅 버튼 보이도록 수정

### DIFF
--- a/apps/homepage/src/app/(with-header)/(with-footer)/(home)/_containers/HomeAttendanceContainer.tsx
+++ b/apps/homepage/src/app/(with-header)/(with-footer)/(home)/_containers/HomeAttendanceContainer.tsx
@@ -20,7 +20,7 @@ export const HomeAttendanceContainer = () => {
         'fixed right-7 bottom-7 z-30 transition-all duration-300',
         'md:hidden'
       )}>
-      {attendanceStatus && <AttendanceFloatingButton />}
+      {attendanceStatus?.openStatus === 'OPEN' && <AttendanceFloatingButton />}
     </div>
   );
 };


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->

close #263 

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->

<br><br>

기존 모바일 뷰에서 출석 상태를 attendanceStatus가 존재하는지 여부에 따라 플로팅 버튼을 렌더링하고 있어, 세션이 생기기만 해도 플로팅 버튼이 활성화되는 문제가 있어서 이를 해결하기 위해 attendanceStatus 내부 openStatus 가 'OPEN'일 때만 플로팅 버튼이 활성화 되게 구현했습니다. 

<img width="347" height="236" alt="image" src="https://github.com/user-attachments/assets/4422ad73-be16-4f08-a56f-73863cfd02c0" />

<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 출석 상태 확인 후 모바일뷰에서 플로팅 버튼 렌더링 확인 
