### PR TITLE
[FIX]: 홈페이지 가입 신청 완료 모달 위치 문제 (QA)

### DIFF
--- a/apps/homepage/src/app/onboarding/_containers/OnboardingContainer.tsx
+++ b/apps/homepage/src/app/onboarding/_containers/OnboardingContainer.tsx
@@ -39,7 +39,8 @@ export const OnboardingContainer = () => {
   const currentConfig = STEP_CONFIG[funnel.step];
 
   return (
-    <div className='custom-scrollbar flex h-fit max-h-[90vh] w-full flex-col gap-11.75 overflow-y-auto rounded-[40px] border border-neutral-100/10 bg-neutral-100/20 px-5 py-9 shadow-xl backdrop-blur-xs sm:min-w-134.75 sm:px-11 sm:py-18.5'>
+    <div className='custom-scrollbar flex h-fit max-h-[90vh] w-full flex-col gap-11.75 overflow-y-auto rounded-[40px] border border-neutral-100/10 bg-neutral-100/20 px-5 py-9 shadow-xl sm:min-w-134.75 sm:px-11 sm:py-18.5'>
+      <div className='absolute inset-0 -z-10 rounded-[40px] backdrop-blur-xs' />
       <div className='flex flex-col gap-4'>
         <div className='flex flex-row justify-between'>
           <h2 className='flex flex-row items-center gap-3.5'>


### PR DESCRIPTION

## ISSUE 🔗

<!-- ex) close #이슈번호 -->
close #264

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->

회원가입 완료 시 나타나는 가입 신청 완료 모달이 전체 화면을 덮지 못하고 `OnboardingContainer` 내부에 갇히는 현상을 수정했습니다.

<img width="3837" height="1890" alt="image" src="https://github.com/user-attachments/assets/4a1ddec7-b62e-4255-b075-9bcc301f897b" />
-> 오류 사진

### 문제 원인
`OnboardingContainer.tsx`에 새롭게 적용된 backdrop-blur-xs 속성이 Stacking 컨텍스트를 생성해서 자식 요소로 위치되어 있는 modal 컴포넌트의 fixed 속성이 뷰포트가 아닌 해당 컨테이너를 기준으로 동작하여 뷰포트 전체를 덮는 오버레이가 작동하지 않았습니다.

### 수정 사항
컨테이너 자체에 적용되어 있던 블러 속성을 제거하고, 배경 레이어를 별도의 태그로 분리해서 모달이 뷰포트 전체를 인식하도록 수정했습니다. 

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->

웹뷰
<img width="622" height="606" alt="image" src="https://github.com/user-attachments/assets/8662d536-5fb7-41ef-91b5-8631e4be3725" />

모바일뷰
<img width="225" height="398" alt="image" src="https://github.com/user-attachments/assets/c5cc8dd7-bf46-4c67-8972-128bc6b24659" />


<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 가입 완료 모달 테스트 
