### PR TITLE
[REFACTOR]: 마이페이지 나의 활동 드롭다운 월 옵션 수정

### DIFF
--- a/apps/homepage/src/app/(with-header)/mypage/activity/_containers/AttendanceCheckContainer.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/activity/_containers/AttendanceCheckContainer.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import {useState} from 'react';
+import {useState, useMemo, useEffect} from 'react';
 import {Dropdown} from '@/components/dropdown/Dropdown';
 import {TabType} from '@/schemas/mypage-mem/activity/mypage-mem-type';
 import {
   useAttendanceRecordsQuery,
   usePenaltyRecordsQuery,
+  useAttendanceDashboardQuery,
 } from '@/hooks/queries/useActivity.queries';
 import {Spinner} from '@repo/ui/components/spinner/Spinner';
 import {AttendanceRows} from '@/app/(with-header)/mypage/activity/_components/AttendanceRow';
@@ -14,25 +15,49 @@ import {MemberAttendResponse} from '@/schemas/mypage-mem/activity/attendance.sch
 import {PenaltyRecord} from '@/schemas/mypage-mem/activity/penalty.schema';
 
 export const AttendanceCheckContainer = ({activeTab}: {activeTab: TabType}) => {
-  const [selectedMonth, setSelectedMonth] = useState(
-    () => `${new Date().getMonth() + 1}월`
-  );
-  const monthOptions = Array.from({length: 12}, (_, i) => `${i + 1}월`);
-  const monthNumber = parseInt(selectedMonth.replace('월', ''));
+  const {data: dashboardData, isLoading: isDashboardLoading} =
+    useAttendanceDashboardQuery();
+  const generationId = dashboardData?.generationId;
 
+  // generationId에 따라 월 옵션
+  const monthOptions = useMemo(() => {
+    if (!generationId) return [];
+    const isOdd = generationId % 2 !== 0;
+    const months = isOdd ? [3, 4, 5, 6, 7, 8] : [9, 10, 11, 12, 1, 2];
+    return months.map((m) => `${m}월`);
+  }, [generationId]);
+
+  const [selectedMonth, setSelectedMonth] = useState<string>('');
+
+  useEffect(() => {
+    if (monthOptions.length > 0 && !selectedMonth) {
+      const currentMonth = new Date().getMonth() + 1;
+      const currentMonthText = `${currentMonth}월`;
+      if (monthOptions.includes(currentMonthText)) {
+        setSelectedMonth(currentMonthText);
+      } else {
+        setSelectedMonth(monthOptions[0] as string);
+      }
+    }
+  }, [monthOptions, selectedMonth]);
+
+  const monthNumber = parseInt(selectedMonth.replace('월', ''));
   const isAttendance = activeTab === 'attendance';
 
   const {data: attendRecords, isLoading: isAttendLoading} =
     useAttendanceRecordsQuery(monthNumber, {
-      enabled: isAttendance,
+      enabled: isAttendance && !!selectedMonth,
     });
 
   const {data: penaltyRecords, isLoading: isPenaltyLoading} =
     usePenaltyRecordsQuery(monthNumber, {
-      enabled: !isAttendance,
+      enabled: !isAttendance && !!selectedMonth,
     });
 
-  const isLoading = isAttendance ? isAttendLoading : isPenaltyLoading;
+  const isDataLoading =
+    isDashboardLoading ||
+    !selectedMonth ||
+    (isAttendance ? isAttendLoading : isPenaltyLoading);
 
   const currentRecords = isAttendance
     ? attendRecords?.attendances || []
@@ -49,51 +74,53 @@ export const AttendanceCheckContainer = ({activeTab}: {activeTab: TabType}) => {
           isBorder
         />
       </div>
-      <div className='rounded-[10px] bg-neutral-50 px-15.75 py-7 text-center'>
-        <table className='w-full table-fixed border-separate border-spacing-y-2.5'>
-          <thead>
-            <tr className='text-h5 h-12.25 bg-white text-neutral-800'>
-              <th>회차</th>
-              {isAttendance ? (
-                <>
-                  <th className='w-1/4'>장소</th>
-                  <th className='w-1/4'>대면여부</th>
-                  <th className='w-1/4'>출석여부</th>
-                </>
+      <div className='flex min-h-75 flex-col justify-center rounded-[10px] bg-neutral-50 px-15.75 py-7 text-center'>
+        {isDataLoading ? (
+          <div className='flex items-center justify-center py-20'>
+            <Spinner />
+          </div>
+        ) : (
+          <table className='w-full table-fixed border-separate border-spacing-y-2.5'>
+            <thead>
+              <tr className='text-h5 h-12.25 bg-white text-neutral-800'>
+                <th>회차</th>
+                {isAttendance ? (
+                  <>
+                    <th className='w-1/4'>장소</th>
+                    <th className='w-1/4'>대면여부</th>
+                    <th className='w-1/4'>출석여부</th>
+                  </>
+                ) : (
+                  <>
+                    <th className='w-1/5'>내용</th>
+                    <th className='w-1/5'>상·벌점</th>
+                    <th className='w-1/5'>점수</th>
+                    <th className='w-1/5'>누계</th>
+                  </>
+                )}
+              </tr>
+            </thead>
+            <tbody className='text-body-l text-neutral-800'>
+              {currentRecords.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={isAttendance ? 4 : 5}
+                    className='py-15 text-neutral-400'>
+                    {isAttendance
+                      ? '출석 내역이 없습니다.'
+                      : '상·벌점 내역이 없습니다.'}
+                  </td>
+                </tr>
+              ) : isAttendance ? (
+                <AttendanceRows
+                  data={currentRecords as MemberAttendResponse[]}
+                />
               ) : (
-                <>
-                  <th className='w-1/5'>내용</th>
-                  <th className='w-1/5'>상·벌점</th>
-                  <th className='w-1/5'>점수</th>
-                  <th className='w-1/5'>누계</th>
-                </>
+                <PenaltyRows data={currentRecords as PenaltyRecord[]} />
               )}
-            </tr>
-          </thead>
-          <tbody className='text-body-l text-neutral-800'>
-            {isLoading ? (
-              <tr>
-                <td colSpan={isAttendance ? 4 : 5} className='py-10'>
-                  <Spinner />
-                </td>
-              </tr>
-            ) : currentRecords.length === 0 ? (
-              <tr>
-                <td
-                  colSpan={isAttendance ? 4 : 5}
-                  className='py-15 text-neutral-400'>
-                  {isAttendance
-                    ? '출석 내역이 없습니다.'
-                    : '상·벌점 내역이 없습니다.'}
-                </td>
-              </tr>
-            ) : isAttendance ? (
-              <AttendanceRows data={currentRecords as MemberAttendResponse[]} />
-            ) : (
-              <PenaltyRows data={currentRecords as PenaltyRecord[]} />
-            )}
-          </tbody>
-        </table>
+            </tbody>
+          </table>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->

close #268

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->

## 마이페이지 나의 활동 드롭다운 월 렌더링 옵션 수정
### 기수에 따른 렌더링 분기
기획과 이야기했던대로 마이페이지 나의 활동 드롭다운의 월 옵션을 수정했습니다.
기존에는 1월부터 12월까지 전부 옵션으로 렌더링했는데, 기수(`generationId`)에 따라 조건적으로 렌더링되게했습니다.
접속한 사용자의 `generationId`는 나의활동 상단에 위치한 대시보드조회 api 응답으로 보내주는게 있어서 query로 그걸 받아와서 설정합니다.

만약 **홀수 기수**라면
- _3~8월만 렌더링_

만약 **짝수 기수**라면
- _9~2월만 렌더링_

되도록했습니다.
<br>

### 초기 월 설정
만약 현재 월이 기수별 월 옵션에 해당되면 현재 월을 초기값으로 선택하여 렌더링합니다.
그런데 만약 그렇지않은 경우에는 기수별 월 옵션의 최상단값(홀수기수는 3월, 짝수기수는 9월)이 초기값으로 선택됩니다.
<br>

### 스피너
스피너는 하나의 전체 스피너로 구현되도록 스피너의 렌더링을 수정했습니다.


<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->
<img width="1624" height="970" alt="스크린샷 2026-03-11 23 41 06" src="https://github.com/user-attachments/assets/197a9f97-67d7-47c6-b64d-1d999da92bf5" />

홀수기수인 경우 (ex. 13기)

<br>

<img width="1624" height="970" alt="스크린샷 2026-03-11 23 39 20" src="https://github.com/user-attachments/assets/57fcdd5a-ff62-40df-88a9-e4ce24d3fc70" />

짝수기수인 경우 (ex. 12기)



<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 홀수기수에서 3~8월로 드롭다운 옵션 렌더링되는지 확인
- [ ] 짝수기수에서 9~2월로 드롭다운 옵션 렌더링되는지 확인
