### PR TITLE
[FIX]: 홈페이지 파트 섹션 하이드레이션 문제

### DIFF
--- a/apps/homepage/src/app/(with-header)/(with-footer)/(home)/_containers/HomePartSectionContainer.tsx
+++ b/apps/homepage/src/app/(with-header)/(with-footer)/(home)/_containers/HomePartSectionContainer.tsx
@@ -69,12 +69,12 @@ export const HomePartSectionContainer = () => {
                 aria-controls={`tabpanel-${currentPart}`}
                 label={
                   partKey === 'pm'
-                    ? '기획'
+                    ? '기획 파트 보기'
                     : partKey === 'design'
-                      ? '디자인'
+                      ? '디자인 파트 보기'
                       : partKey === 'frontend'
-                        ? '프론트엔드'
-                        : '백엔드'
+                        ? '프론트엔드 파트 보기'
+                        : '백엔드 파트 보기'
                 }
                 width={220}
                 labelTypo='h3'
@@ -94,11 +94,7 @@ export const HomePartSectionContainer = () => {
           className='relative h-60 w-full overflow-hidden rounded-lg bg-neutral-900 xl:h-140 xl:rounded-[40px]'
           id={`tabpanel-${currentPart}`}
           role='tabpanel'
-          aria-labelledby={
-            typeof window !== 'undefined' && window.innerWidth >= 1280
-              ? `tab-desktop-${currentPart}`
-              : `tab-mobile-${currentPart}`
-          }
+          aria-labelledby={`tab-${currentPart}`}
           tabIndex={0}>
           <AnimatePresence mode='popLayout' custom={direction}>
             <motion.div
@@ -155,7 +151,7 @@ export const HomePartSectionContainer = () => {
         <div
           className='flex justify-center xl:hidden'
           role='tablist'
-          aria-label='파트 선택 (모바일)'>
+          aria-label='파트 선택'>
           {PARTS.map((partKey) => (
             <button
               key={partKey}


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->

close #270 

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->

홈 화면의 '코테이토 4가지 파트' 섹션(HomePartSectionContainer)에서 발생하던 하이드레이션 오류를 해결했습니다.


### 문제 원인
기존 코드에서 aria-labelledby 값을 결정할 때 window.innerWidth 를 직접 참조하는 조건부 로직을 사용하였고,

이로 인해 서버(SSR)는 window 객체가 없어서 기본값으로 HTML을 생성하여 전달, 클라이언트는 브라우저 환경에 따라 다른 ID를 할당하려 함으로 인해 서버와 클라이언트 초기 렌더링 결과가 일치하지 않았던 하이드레이션 오류가 발생했습니다.

### 수정 사항

기존 window.innerWidth 에 의존하던 분기 처리 로직을 제거하여, 상시 존재하는 값을 참조하도록 변경했습니다. 

<br><br>
## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 홈 경로 접근 시 하이드레이션 에러 확인 
