### PR TITLE
[FIX]: 활동 회원 페이지네이션 버그 수정

### DIFF
--- a/apps/homepage/src/app/(with-header)/mypage/admin/users/_hooks/useActiveMembersTable.ts
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/users/_hooks/useActiveMembersTable.ts
@@ -34,7 +34,7 @@ export const useActiveMembersTable = () => {
   const isCurrentGeneration =
     generation.selectedGeneration !== null &&
     generation.selectedGeneration === generation.defaultGenerationId;
-  const totalPages = data ? (data.isLast ? data.page + 1 : data.page + 2) : 1;
+  const totalPages = data?.totalPages ?? 1;
 
   const modals = useActiveMembersModals({members, isCurrentGeneration});
   const {mutate: patchRoleMutate} = usePatchActiveMemberRole();

--- a/apps/homepage/src/schemas/admin/admin-members.schema.ts
+++ b/apps/homepage/src/schemas/admin/admin-members.schema.ts
@@ -85,6 +85,8 @@ export const ActiveMemberSchema = z.object({
 export const ActiveMembersPageResponseSchema = z.object({
   content: z.array(ActiveMemberSchema),
   hasNext: z.boolean(),
+  totalPages: z.number(),
+  totalElements: z.number(),
   page: z.number(),
   size: z.number(),
   isFirst: z.boolean(),


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->
close #277
<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->
이전의 활동 회원은 전체 회원 부분과 달리 totalPages를 넘겨주지 않아 저번 QA 이후 제가 수동 계산하는 로직을 추가했었는데요,
아무래도 여기에서 예외가 터져 어제 같은 페이지 개수가 다르게 보이는 버그가 발생한 것 같습니다...
이제는 totalPages를 보내주기 때문에! 어제 같은 이슈는 없어요 제가 계산할 일이 없기 때문입니다!
<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->
![화면 기록 2026-03-12 오전 11 23 08](https://github.com/user-attachments/assets/6b110fb7-a9cf-4319-9b98-c3387f8d33d2)

<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 사실 뭐 지금은 잘 보여서 배포 후에 페이지네이션 문제 없는지 ui 체크만 하면 될 것 같습니다
