### PR TITLE
[UI]: 리쿠르팅 마이 페이지 반응형 최적화

### DIFF
--- a/apps/recruit/src/app/(with-footer)/my-page/_containers/MyPageSubmittedApplicationsContainer.tsx
+++ b/apps/recruit/src/app/(with-footer)/my-page/_containers/MyPageSubmittedApplicationsContainer.tsx
@@ -47,9 +47,7 @@ export const MyPageSubmittedApplicationsContainer = () => {
                   <th className='rounded-l-[10px] bg-white px-2 py-2.5 lg:px-6 lg:py-4'>
                     기수
                   </th>
-                  <th className='bg-white py-2.5 lg:px-6 lg:py-4'>
-                    <span className='hidden lg:inline'>지원 </span>파트
-                  </th>
+                  <th className='bg-white py-2.5 lg:px-6 lg:py-4'>지원 파트</th>
                   <th className='bg-white px-2 py-2.5 lg:px-6 lg:py-4'>
                     지원 상태
                   </th>

--- a/apps/recruit/src/app/(with-footer)/my-page/_containers/MyPageSubmittedApplicationsContainer.tsx
+++ b/apps/recruit/src/app/(with-footer)/my-page/_containers/MyPageSubmittedApplicationsContainer.tsx
@@ -24,7 +24,6 @@ export const MyPageSubmittedApplicationsContainer = () => {
         <Spinner />
       </div>
     );
-
   if (isError)
     return (
       <div className='text-alert py-20 text-center'>
@@ -33,71 +32,70 @@ export const MyPageSubmittedApplicationsContainer = () => {
     );
 
   return (
-    <div className='flex flex-col items-center justify-center bg-white py-23'>
-      <div className='flex flex-col gap-5'>
-        <h1 className='text-h4 flex w-full items-start font-bold text-neutral-800'>
+    <div className='flex w-full flex-col items-center justify-center bg-white px-4 py-7.5 lg:px-6 lg:py-23'>
+      <div className='flex w-full max-w-275 flex-col gap-5'>
+        <h1 className='text-h3 lg:text-h4 font-bold text-neutral-800'>
           마이페이지
         </h1>
-        <div className='flex min-h-79.25 max-w-480 min-w-275 flex-col items-center justify-center gap-8 rounded-[10px] bg-neutral-50 px-20'>
-          <h2 className='text-h4 flex w-full items-start text-neutral-800'>
-            지원 현황
-          </h2>
-          <div className='w-275 overflow-hidden'>
-            <table className='w-full border-separate border-spacing-0 text-center'>
-              <thead className='text-h5 rounded-[10px] bg-white text-neutral-500'>
+        <div className='flex flex-col gap-5 rounded-[10px] bg-neutral-50 p-3.5 pb-17 lg:gap-8 lg:px-20 lg:py-7.5'>
+          <h2 className='text-h4 font-bold text-neutral-800'>지원 현황</h2>
+
+          <div className='w-full overflow-x-auto'>
+            <table className='w-full min-w-[320px] table-auto border-separate border-spacing-0 text-center'>
+              <thead className='text-body-l lg:text-h5 font-bold text-neutral-500 lg:font-semibold'>
                 <tr>
-                  <th className='rounded-l-[10px] bg-white px-6 py-4 font-semibold'>
+                  <th className='rounded-l-[10px] bg-white px-2 py-2.5 lg:px-6 lg:py-4'>
                     기수
                   </th>
-                  <th className='bg-white px-6 py-4 font-semibold'>
-                    지원 파트
+                  <th className='bg-white py-2.5 lg:px-6 lg:py-4'>
+                    <span className='hidden lg:inline'>지원 </span>파트
                   </th>
-                  <th className='bg-white px-6 py-4 text-center font-semibold'>
+                  <th className='bg-white px-2 py-2.5 lg:px-6 lg:py-4'>
                     지원 상태
                   </th>
-                  <th className='rounded-r-[10px] bg-white px-6 py-4 text-center font-semibold'>
+                  <th className='rounded-r-[10px] bg-white px-2 py-2.5 lg:px-6 lg:py-4'>
                     지원서
                   </th>
                 </tr>
               </thead>
-              <tbody>
+              <tbody className='text-neutral-800'>
                 {applications?.map((item) => (
                   <tr key={item.applicationId}>
-                    <td className='text-body-l px-6 py-5 text-neutral-800'>
-                      {item.generationNumber}
+                    <td className='text-body-m lg:text-body-l py-3 font-bold lg:py-5 lg:font-normal'>
+                      {item.generationNumber}기
                     </td>
-                    <td className='text-body-l px-6 py-5 text-neutral-800'>
+                    <td className='text-body-m lg:text-body-l py-3 lg:px-6 lg:py-5'>
                       {PART_MAP[item.part as keyof typeof PART_MAP] ||
                         item.part}
                     </td>
-                    <td className='px-6 py-5 text-center'>
-                      <span className='bg-primary text-body-l-sb rounded-[10px] px-4 py-2 text-white'>
+                    <td className='py-3 lg:px-6 lg:py-5'>
+                      <span className='bg-primary lg:text-body-l-sb text-body-m inline-block rounded-[10px] px-2 py-1 font-bold text-white lg:px-4'>
                         {item.status}
                       </span>
                     </td>
-                    <td className='text-body-l flex justify-center px-6 py-5 text-center'>
+                    <td className='py-3 lg:px-6 lg:py-5'>
                       <button
-                        className='flex flex-row items-center gap-1 text-center text-neutral-800'
+                        className='flex w-full items-center justify-center gap-0.5 text-center text-neutral-800 hover:opacity-70'
                         onClick={() =>
                           handleApplicationClick(item.applicationId)
                         }>
-                        <span>지원서 확인하기</span>
-                        <ChevronRight className='h-5 w-5 text-neutral-800' />
+                        <p className='text-body-l flex gap-1'>
+                          <span className='hidden lg:inline'>지원서</span>
+                          <span>확인하기</span>
+                        </p>
+                        <ChevronRight className='h-4 w-4 lg:h-5 lg:w-5' />
                       </button>
                     </td>
                   </tr>
                 ))}
-                {applications?.length === 0 && (
-                  <tr>
-                    <td
-                      colSpan={4}
-                      className='text-body-l py-10 text-center text-neutral-800'>
-                      아직 지원하신 내용이 없습니다.
-                    </td>
-                  </tr>
-                )}
               </tbody>
             </table>
+
+            {applications?.length === 0 && (
+              <div className='py-10 text-center text-neutral-600'>
+                아직 지원하신 내용이 없습니다.
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/apps/recruit/src/app/(with-footer)/my-page/detail/_containers/MyPageApplicationDetailContainer.tsx
+++ b/apps/recruit/src/app/(with-footer)/my-page/detail/_containers/MyPageApplicationDetailContainer.tsx
@@ -53,16 +53,17 @@ export const MyPageApplicationDetailContainer = () => {
 
   return (
     <div className='mx-auto flex w-full max-w-275 flex-col gap-10 py-7.5 lg:py-10'>
-      <div className='flex justify-center'>
-        <StepIndicator currentStep={step} totalSteps={3} />
-      </div>
-
       <div className='min-h-150 w-full rounded-[20px] lg:p-10'>
         {step === 1 && (
-          <BasicInfoView
-            basicInfo={basicInfo.data}
-            onNext={() => handleStepChange(2)}
-          />
+          <>
+            <div className='flex justify-center'>
+              <StepIndicator currentStep={step} totalSteps={3} />
+            </div>
+            <BasicInfoView
+              basicInfo={basicInfo.data}
+              onNext={() => handleStepChange(2)}
+            />
+          </>
         )}
 
         {step === 2 && (
@@ -73,6 +74,9 @@ export const MyPageApplicationDetailContainer = () => {
               )?.label ?? '-'}{' '}
               파트에 관한 질문입니다.
             </h3>
+            <div className='flex justify-center'>
+              <StepIndicator currentStep={step} totalSteps={3} />
+            </div>
             <PartQuestionView
               questionsWithAnswers={partQuestions.data.questionsWithAnswers}
               pdfFileUrl={partQuestions.data.pdfFileUrl}
@@ -88,6 +92,9 @@ export const MyPageApplicationDetailContainer = () => {
             <h3 className='text-h5 lg:text-h3 font-bold text-neutral-800'>
               기타 질문
             </h3>
+            <div className='flex justify-center'>
+              <StepIndicator currentStep={step} totalSteps={3} />
+            </div>
             <EtcQuestionView
               etcQuestions={etcQuestions.data}
               onPrev={() => handleStepChange(2)}

--- a/apps/recruit/src/app/(with-footer)/my-page/detail/_containers/MyPageApplicationDetailContainer.tsx
+++ b/apps/recruit/src/app/(with-footer)/my-page/detail/_containers/MyPageApplicationDetailContainer.tsx
@@ -52,12 +52,12 @@ export const MyPageApplicationDetailContainer = () => {
   if (!basicInfo || !partQuestions || !etcQuestions) return null;
 
   return (
-    <div className='mx-auto flex max-w-275 flex-col gap-10 py-10'>
+    <div className='mx-auto flex w-full max-w-275 flex-col gap-10 py-7.5 lg:py-10'>
       <div className='flex justify-center'>
         <StepIndicator currentStep={step} totalSteps={3} />
       </div>
 
-      <div className='min-h-150 rounded-[20px] p-10'>
+      <div className='min-h-150 w-full rounded-[20px] lg:p-10'>
         {step === 1 && (
           <BasicInfoView
             basicInfo={basicInfo.data}
@@ -67,7 +67,7 @@ export const MyPageApplicationDetailContainer = () => {
 
         {step === 2 && (
           <div className='flex flex-col gap-6'>
-            <h3 className='text-h3 text-primary font-bold'>
+            <h3 className='text-h5 lg:text-h3 text-primary font-bold'>
               {APPLICATIONS_PART_TABS.find(
                 (tab) => tab.value === basicInfo.data.applicationPartType
               )?.label ?? '-'}{' '}
@@ -85,7 +85,9 @@ export const MyPageApplicationDetailContainer = () => {
 
         {step === 3 && (
           <div className='flex flex-col gap-6'>
-            <h3 className='text-h3 font-bold text-neutral-800'>기타 질문</h3>
+            <h3 className='text-h5 lg:text-h3 font-bold text-neutral-800'>
+              기타 질문
+            </h3>
             <EtcQuestionView
               etcQuestions={etcQuestions.data}
               onPrev={() => handleStepChange(2)}

--- a/apps/recruit/src/app/(with-footer)/my-page/detail/page.tsx
+++ b/apps/recruit/src/app/(with-footer)/my-page/detail/page.tsx
@@ -3,7 +3,7 @@ import {SuspenseWrapper} from '@/components/wrappers/SuspenseWrapper';
 
 export default function MyPageApplicationDetailPage() {
   return (
-    <section className='bg-white'>
+    <section className='flex w-full flex-col bg-white px-6'>
       <SuspenseWrapper>
         <MyPageApplicationDetailContainer />
       </SuspenseWrapper>

--- a/apps/recruit/src/app/(with-footer)/my-page/page.tsx
+++ b/apps/recruit/src/app/(with-footer)/my-page/page.tsx
@@ -5,17 +5,17 @@ import {MyPageSubmittedApplicationsContainer} from '@/app/(with-footer)/my-page/
 
 export default function Mypage() {
   return (
-    <section className='flex w-full min-w-360 flex-col items-center bg-white'>
+    <section className='flex w-full flex-col items-center bg-white'>
       <HeroMainBanner
         heading='COde Together, Arrive TOgether'
         headingStyle='bg-linear-to-r from-[#F89202] from-0% via-[#F89202] via-10% to-[#9E9E9E] to-100% bg-clip-text text-transparent'
         bannerImage={
           <Image
             src={HeroBanner}
-            alt='Hero Banner'
+            alt='마이페이지 배너'
             fill
             priority
-            className='object-cover object-center'
+            className='object-cover object-left lg:object-center'
           />
         }
       />

--- a/apps/recruit/src/app/_mobile/HeaderMobileMenu.tsx
+++ b/apps/recruit/src/app/_mobile/HeaderMobileMenu.tsx
@@ -102,7 +102,7 @@ export const HeaderMobileMenu = ({
                   <Link
                     href={ROUTES.MYPAGE}
                     onClick={onClose}
-                    className={`text-h5 px-4 font-bold transition-all duration-300 hover:text-neutral-50 ${
+                    className={`text-h5 px-4 transition-all duration-300 hover:text-neutral-50 ${
                       pathname.startsWith(ROUTES.MYPAGE)
                         ? 'text-primary'
                         : 'text-neutral-400'

--- a/apps/recruit/src/app/_mobile/HeaderMobileMenu.tsx
+++ b/apps/recruit/src/app/_mobile/HeaderMobileMenu.tsx
@@ -90,7 +90,7 @@ export const HeaderMobileMenu = ({
                     href={href}
                     onClick={onClose}
                     className={`text-h5 px-4 transition-all duration-300 hover:text-neutral-50 ${
-                      isActive ? 'text-neutral-50' : 'text-neutral-400'
+                      isActive ? 'text-primary' : 'text-neutral-400'
                     }`}>
                     {label}
                   </Link>

--- a/apps/recruit/src/components/application/BasicInfoView.tsx
+++ b/apps/recruit/src/components/application/BasicInfoView.tsx
@@ -11,22 +11,22 @@ interface BasicInfoViewProps {
 
 export const BasicInfoView = ({onNext, basicInfo}: BasicInfoViewProps) => {
   return (
-    <div className='flex flex-col gap-4 sm:gap-6'>
+    <div className='flex flex-col gap-4 py-5 lg:gap-6'>
       <FormInput
         label={BASIC_INFO_LABELS.name}
         readOnly
         value={basicInfo.name}
       />
 
-      <div className='flex flex-col gap-4 sm:flex-row sm:gap-10'>
-        <div className='flex-1'>
+      <div className='flex flex-row gap-10 lg:gap-10'>
+        <div className='min-w-0 flex-1'>
           <FormInput
             label={BASIC_INFO_LABELS.gender}
             readOnly
             value={getGenderLabel(basicInfo.gender)}
           />
         </div>
-        <div className='flex-1'>
+        <div className='min-w-0 flex-1'>
           <FormInput
             label={BASIC_INFO_LABELS.birthDate}
             readOnly
@@ -41,7 +41,7 @@ export const BasicInfoView = ({onNext, basicInfo}: BasicInfoViewProps) => {
         value={basicInfo.phoneNumber}
       />
 
-      <div className='flex flex-col gap-4 sm:flex-row sm:gap-11.75'>
+      <div className='flex flex-col gap-4 lg:flex-row lg:gap-11.75'>
         <div className='flex-1'>
           <FormInput
             label={BASIC_INFO_LABELS.school}
@@ -50,7 +50,7 @@ export const BasicInfoView = ({onNext, basicInfo}: BasicInfoViewProps) => {
           />
         </div>
 
-        <div className='flex flex-row items-end gap-6 sm:gap-11.75'>
+        <div className='flex flex-row items-end gap-6 lg:gap-11.75'>
           <FormRadio
             readOnly
             label={BASIC_INFO_LABELS.enrollmentStatus}
@@ -70,15 +70,15 @@ export const BasicInfoView = ({onNext, basicInfo}: BasicInfoViewProps) => {
         value={basicInfo.major}
       />
 
-      <div className='flex flex-col gap-4 sm:flex-row sm:gap-17.5'>
-        <div className='flex-1'>
+      <div className='flex flex-row gap-10 lg:gap-17.5'>
+        <div className='min-w-0 flex-1'>
           <FormInput
             label={BASIC_INFO_LABELS.completedSemesters}
             readOnly
             value={basicInfo.completedSemesters}
           />
         </div>
-        <div className='flex-1'>
+        <div className='min-w-0 flex-1'>
           <FormInput
             label={BASIC_INFO_LABELS.isPrevActivity}
             readOnly
@@ -91,8 +91,8 @@ export const BasicInfoView = ({onNext, basicInfo}: BasicInfoViewProps) => {
         <FullButton
           label='다음'
           onClick={onNext}
-          height={54}
-          className='text-h4'
+          wrapperClassName='lg:h-[54px] h-[42px]'
+          className='text-h5 lg:text-h4'
         />
       </div>
     </div>

--- a/apps/recruit/src/components/application/EtcQuestionView.tsx
+++ b/apps/recruit/src/components/application/EtcQuestionView.tsx
@@ -21,7 +21,7 @@ export const EtcQuestionView = ({
   etcQuestions,
 }: EtcQuestionViewProps) => {
   return (
-    <div className='flex flex-col gap-4'>
+    <div className='flex flex-col gap-4 py-5'>
       <FormInput
         label={ETC_QUESTION_LABELS.discoveryPath}
         value={
@@ -49,7 +49,7 @@ export const EtcQuestionView = ({
       </div>
 
       <div className='flex flex-col gap-4'>
-        <label className='sm:text-h5 text-body-l-b text-neutral-800'>
+        <label className='lg:text-h5 text-body-l-b text-neutral-800'>
           {ETC_QUESTION_LABELS.sessionAttendance}
         </label>
         <FormRadio
@@ -59,7 +59,7 @@ export const EtcQuestionView = ({
         />
       </div>
       <div className='flex flex-col gap-4'>
-        <label className='sm:text-h5 text-body-l-b text-neutral-800'>
+        <label className='lg:text-h5 text-body-l-b text-neutral-800'>
           최종 합격 시 대면 OT({etcQuestions.otDate ?? '-'}), 코커톤(
           {etcQuestions.cokerthonDate}), 데모데이(
           {etcQuestions.demoDayDate})는 필수 참여입니다.
@@ -77,7 +77,7 @@ export const EtcQuestionView = ({
           value={PRIVACY_POLICY}
           readOnly
         />
-        <div className='flex justify-end'>
+        <div className='flex lg:justify-end'>
           <FormRadio
             label={ETC_QUESTION_LABELS.privacyPolicy_answer}
             readOnly
@@ -90,8 +90,8 @@ export const EtcQuestionView = ({
         label='이전'
         onClick={onPrev}
         backgroundColor='neutral-600'
-        height={54}
-        className='sm:text-h4 text-h5'
+        wrapperClassName='h-[42px] lg:h-[54px]'
+        className='lg:text-h4 text-h5'
       />
     </div>
   );

--- a/apps/recruit/src/components/application/PartQuestionView.tsx
+++ b/apps/recruit/src/components/application/PartQuestionView.tsx
@@ -49,7 +49,7 @@ export const PartQuestionView = ({
     questionsWithAnswers[questionsWithAnswers.length - 1]?.sequence;
 
   return (
-    <div className='flex flex-col gap-3.5 sm:gap-10'>
+    <div className='flex flex-col gap-3.5 py-5 lg:gap-10'>
       {questionsWithAnswers.map((data) => {
         const isLastQuestion = data.sequence === lastSequence;
 
@@ -95,20 +95,20 @@ export const PartQuestionView = ({
         );
       })}
 
-      <div className='flex flex-row gap-7.5'>
+      <div className='flex flex-row gap-3 lg:gap-7.5'>
         <FullButton
           label='이전'
           backgroundColor='neutral-600'
           onClick={onPrev}
-          height={54}
-          className='sm:text-h4 text-h5'
+          wrapperClassName='lg:h-[54px] h-[42px]'
+          className='lg:text-h4 text-h5'
         />
 
         <FullButton
           label='다음'
           onClick={onNext}
-          height={54}
-          className='sm:text-h4 text-h5'
+          wrapperClassName='lg:h-[54px] h-[42px]'
+          className='lg:text-h4 text-h5'
         />
       </div>
     </div>

--- a/apps/recruit/src/components/form/FormRadio.tsx
+++ b/apps/recruit/src/components/form/FormRadio.tsx
@@ -12,7 +12,7 @@ export const FormRadio = forwardRef<HTMLInputElement, FormRadioProps>(
     return (
       <label
         className={clsx(
-          'flex cursor-pointer items-center gap-6 whitespace-nowrap',
+          'flex cursor-pointer items-center gap-3 whitespace-nowrap lg:gap-6',
           readOnly && 'pointer-events-none cursor-default',
           className
         )}>
@@ -36,7 +36,7 @@ export const FormRadio = forwardRef<HTMLInputElement, FormRadioProps>(
           <div className='bg-active pointer-events-none absolute size-3.5 scale-0 rounded-full transition-transform duration-200 peer-checked:scale-100' />
         </div>
 
-        <span className='sm:text-h5 text-body-l-b font-semibold text-neutral-600'>
+        <span className='lg:text-h5 text-body-l-b font-semibold text-neutral-600'>
           {label}
         </span>
       </label>

--- a/apps/recruit/src/components/navigation/StepIndicator.tsx
+++ b/apps/recruit/src/components/navigation/StepIndicator.tsx
@@ -10,7 +10,7 @@ export const StepIndicator = ({
   totalSteps = 3,
 }: StepIndicatorProps) => {
   return (
-    <div className='flex w-full items-center justify-between gap-6.25 md:px-50'>
+    <div className='flex w-full items-center justify-between gap-6.25 lg:px-50'>
       {Array.from({length: totalSteps}, (_, index) => {
         const step = index + 1;
         const isCurrent = step === currentStep;
@@ -18,13 +18,13 @@ export const StepIndicator = ({
         return (
           <div key={step} className='flex flex-1 items-center last:flex-none'>
             <LogoIcon
-              className={`h-3.5 w-3.5 shrink-0 sm:h-10 sm:w-10 ${
+              className={`h-3.5 w-3.5 shrink-0 lg:h-10 lg:w-10 ${
                 isCurrent ? 'text-hover' : 'text-neutral-300'
               }`}
             />
 
             {index < totalSteps - 1 && (
-              <div className='mx-2 h-0 flex-1 border-t-2 border-dotted border-[#E0E0E0] sm:mx-4' />
+              <div className='mx-2 h-0 flex-1 border-t-2 border-dotted border-[#E0E0E0] lg:mx-4' />
             )}
           </div>
         );

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -44,6 +44,7 @@
     "react-dom": "^19.2.0"
   },
   "dependencies": {
-    "focus-trap-react": "^11.0.4"
+    "focus-trap-react": "^11.0.4",
+    "framer-motion": "^12.31.0"
   }
 }

--- a/packages/ui/src/components/banner/HeroMainBanner.tsx
+++ b/packages/ui/src/components/banner/HeroMainBanner.tsx
@@ -1,4 +1,11 @@
+'use client';
+
+import {motion} from 'framer-motion';
 import clsx from 'clsx';
+import {
+  FADE_IN_UP_CONTAINER,
+  FADE_IN_UP_ITEM,
+} from '../../constants/motion-variants';
 
 interface HeroMainBannerProps {
   subheading?: string;
@@ -20,29 +27,38 @@ const HeroMainBanner = ({
     <aside
       role='banner'
       className={clsx(
-        'relative w-full px-10 lg:h-61 lg:px-60',
+        'relative w-full overflow-hidden px-10 lg:h-61 lg:px-60',
         paddingVertical ? 'h-50 py-[59px] lg:py-[79px]' : 'h-auto py-[104px]'
       )}>
       {bannerImage && <>{bannerImage}</>}
+
       <div
         className='absolute inset-0 h-full w-full bg-[#000000]/60'
         aria-hidden='true'
       />
 
-      <div className='relative z-10 flex flex-col gap-2.5 lg:gap-6'>
+      <motion.div
+        className='relative z-10 flex flex-col gap-2.5 lg:gap-6'
+        variants={FADE_IN_UP_CONTAINER}
+        initial='hidden'
+        animate='visible'>
         {subheading && (
-          <p className='text-h5 lg:text-h4 whitespace-nowrap text-neutral-400'>
+          <motion.p
+            className='text-h5 lg:text-h4 whitespace-nowrap text-neutral-400'
+            variants={FADE_IN_UP_ITEM}>
             {subheading}
-          </p>
+          </motion.p>
         )}
-        <h1
+
+        <motion.h1
           className={clsx(
             'text-h5 lg:text-h3 w-min font-bold whitespace-nowrap text-neutral-100',
             headingStyle
-          )}>
+          )}
+          variants={FADE_IN_UP_ITEM}>
           {heading}
-        </h1>
-      </div>
+        </motion.h1>
+      </motion.div>
     </aside>
   );
 };

--- a/packages/ui/src/components/form/FormLink.tsx
+++ b/packages/ui/src/components/form/FormLink.tsx
@@ -60,20 +60,22 @@ export const FormLink = forwardRef<HTMLInputElement, FormLinkProps>(
                   className={clsx(
                     formFieldStyles.field,
                     formFieldStyles.readOnlyForm,
-                    'flex flex-row items-center gap-5 rounded-lg px-4 py-3'
+                    'grid w-full min-w-0 grid-cols-[auto_1fr] items-center gap-5 rounded-lg px-4 py-3'
                   )}>
                   {!hideInnerLabel && (
-                    <label className='sm:text-h5 text-body-l-b shrink-0 text-neutral-600'>
+                    <label className='lg:text-h5 text-body-l-b shrink-0 text-neutral-600'>
                       링크 {displayLinks.length > 1 ? index + 1 : ''}
                     </label>
                   )}
-                  <a
-                    href={link.startsWith('http') ? link : `https://${link}`}
-                    target='_blank'
-                    rel='noopener noreferrer'
-                    className='text-blue flex-1 truncate underline'>
-                    {link}
-                  </a>
+                  <div className='no-scrollbar min-w-0 flex-1 overflow-x-auto whitespace-nowrap'>
+                    <a
+                      href={link.startsWith('http') ? link : `https://${link}`}
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      className='text-blue inline-block underline'>
+                      {link}
+                    </a>
+                  </div>
                 </div>
               ))
             ) : (
@@ -89,7 +91,7 @@ export const FormLink = forwardRef<HTMLInputElement, FormLinkProps>(
               'flex flex-row items-center gap-5 rounded-lg px-4 py-3'
             )}>
             {!hideInnerLabel && (
-              <label className='sm:text-h5 text-body-l-b shrink-0 text-neutral-600'>
+              <label className='lg:text-h5 text-body-l-b shrink-0 text-neutral-600'>
                 링크
               </label>
             )}

--- a/packages/ui/src/components/form/form.styles.ts
+++ b/packages/ui/src/components/form/form.styles.ts
@@ -1,14 +1,14 @@
 export const formFieldStyles = {
   wrapper: 'flex w-full flex-col gap-2.5',
-  label: 'text-body-l-b sm:text-h5 text-neutral-800 whitespace-pre-line',
+  label: 'text-body-l-b lg:text-h5 text-neutral-800 whitespace-pre-line',
   required: 'text-alert ml-1',
   field:
-    'placeholder-h5 sm:placeholder-body-l rounded-[10px] border-[1px] border-neutral-200 px-4 py-2.75 placeholder:text-neutral-400 focus:outline-none bg-white',
+    'placeholder-h5 lg:placeholder-body-l rounded-[10px] border-[1px] border-neutral-200 px-4 py-2.75 placeholder:text-neutral-400 focus:outline-none bg-white',
   fieldFocus: 'focus:ring-2 focus:ring-primary',
   errorFocus: 'focus:ring-0 focus:outline-none',
   error: '!border-alert',
-  errorMessage: 'text-h5 sm:text-body-l text-alert',
+  errorMessage: 'text-h5 lg:text-body-l text-alert',
   errorContainer: 'min-h-[24px]',
-  readOnlyForm: 'text-h5 text-neutral-800 cursor-default font-bold',
-  readOnlyTextarea: 'text-h5 sm:text-body-l font-normal text-neutral-600',
+  readOnlyForm: 'text-h5 text-neutral-600 cursor-default lg:font-bold',
+  readOnlyTextarea: 'text-h5 lg:text-body-l font-normal text-neutral-600',
 };

--- a/packages/ui/src/constants/motion-variants.ts
+++ b/packages/ui/src/constants/motion-variants.ts
@@ -1,0 +1,26 @@
+import {Variants} from 'framer-motion';
+
+export const FADE_IN_UP_CONTAINER: Variants = {
+  hidden: {opacity: 0},
+  visible: {
+    opacity: 1,
+    transition: {
+      staggerChildren: 0.25,
+      delayChildren: 0.1,
+    },
+  },
+};
+export const FADE_IN_UP_ITEM: Variants = {
+  hidden: {
+    opacity: 0,
+    y: 15,
+  },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: {
+      duration: 1.2,
+      ease: [0.22, 1, 0.36, 1],
+    },
+  },
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,6 +280,9 @@ importers:
       focus-trap-react:
         specifier: ^11.0.4
         version: 11.0.6(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      framer-motion:
+        specifier: ^12.31.0
+        version: 12.31.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -6952,6 +6955,15 @@ snapshots:
   fragment-cache@0.2.1:
     dependencies:
       map-cache: 0.2.2
+
+  framer-motion@12.31.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
+      motion-dom: 12.30.1
+      motion-utils: 12.29.2
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
 
   framer-motion@12.31.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->
close #318 

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->
리쿠르팅 > 마이페이지의 지원 현황 페이지, 지원 상세 페이지의 반응형 최적화를 진행했습니다.

### 지원 현황 페이지 반응형 UI 

lg 쿼리 기준으로 반응형 UI를 구현했습니다.
lg 기준 이하일 경우 지원서 필드 밑 '지원서 확인하기' 텍스트가 '확인하기' 로 줄어들은 상태로 렌더링됩니다. 
레이아웃 깨짐 방지를 위해 380px 이하일 경우 가로 스크롤로 테이블을 확인할 수 있습니다. 


### 지원 상세 view 페이지 반응형 UI 
기존 지원서 확인 페이지 컴포넌트에 쓰이는 공용 폼 컴포넌트에 반응형 처리를 추가했습니다.
지금 디자인대로면 기존 웹뷰와는 다르게 모바일뷰에서 '기수, 파트명, 이름' 필드가 추가되고 StepIndicator.tsx 위치가 다르게 구현되어야 하는데 일단 문의해 둔 상태고 웹뷰와 위치는 동일하게 구현해 뒀습니다. 


### 공용 배너 컴포넌트에 framer-motion을 사용한 애니메이션 처리 추가 
기존 홈페이지에 사용되었던 framer-motion 공용 variant를 사용해 배너 컴포넌트 텍스트에도 컨테이너 베리언트, 아이템 베리언트 애니메이션이 추가되었습니다. 
관련 부분 구현하면서 packages/ui 내부에 framer-motion 의존성이 추가되었습니다.


<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->
![Animation](https://github.com/user-attachments/assets/ffefc1ef-717a-48a3-b609-9e405454f321)
![Animation](https://github.com/user-attachments/assets/53131759-177d-4a39-a0f9-84de29c0f229)

<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 마이페이지 반응형 테스트 
