### PR TITLE
[UI]: 리크루트 마이페이지 어드민 합격자관리 모바일뷰 구현

### DIFF
--- a/apps/recruit/src/app/admin/(with-sidebar)/results/_components/ResultsContainer.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/results/_components/ResultsContainer.tsx
@@ -44,7 +44,7 @@ export const ResultsContainer = () => {
   }
 
   return (
-    <div className='mt-5 flex flex-col gap-3.5 lg:mt-0'>
+    <div className='mt-5 flex flex-col gap-5 lg:mt-0 lg:gap-3.5'>
       <ManageResult
         generation={currentGeneration}
         onGenerationChange={setSelectedGen}

--- a/apps/recruit/src/app/admin/(with-sidebar)/results/_components/ResultsContainer.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/results/_components/ResultsContainer.tsx
@@ -44,7 +44,7 @@ export const ResultsContainer = () => {
   }
 
   return (
-    <div className='flex flex-col gap-3.5'>
+    <div className='mt-5 flex flex-col gap-3.5 lg:mt-0'>
       <ManageResult
         generation={currentGeneration}
         onGenerationChange={setSelectedGen}

--- a/apps/recruit/src/app/admin/(with-sidebar)/results/_components/mail-manage/MailSelect.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/results/_components/mail-manage/MailSelect.tsx
@@ -12,7 +12,7 @@ interface MailSelectProps {
 export const MailSelect = ({activeTab, onTabChange}: MailSelectProps) => {
   return (
     <nav aria-label='합격자 관리 - 메일 전송 탭'>
-      <ul className='flex gap-12.5'>
+      <ul className='flex justify-between gap-8 lg:justify-start lg:gap-12.5'>
         {mailTabs.map((tab) => {
           const isActive = activeTab === tab;
           return (
@@ -23,7 +23,10 @@ export const MailSelect = ({activeTab, onTabChange}: MailSelectProps) => {
                 borderRadius={0}
                 backgroundColor='white'
                 textColor={isActive ? 'neutral-800' : 'neutral-500'}
-                className={clsx('px-0', 'border-none')}
+                className={clsx(
+                  'border-none px-0',
+                  'text-body-l-b! lg:text-h5!'
+                )}
                 onClick={() => onTabChange(tab)}
               />
             </li>

--- a/apps/recruit/src/app/admin/(with-sidebar)/results/_components/mail-manage/MailSelect.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/results/_components/mail-manage/MailSelect.tsx
@@ -19,7 +19,6 @@ export const MailSelect = ({activeTab, onTabChange}: MailSelectProps) => {
             <li key={tab}>
               <FullButton
                 label={tab}
-                height={40}
                 borderRadius={0}
                 backgroundColor='white'
                 textColor={isActive ? 'neutral-800' : 'neutral-500'}
@@ -27,6 +26,7 @@ export const MailSelect = ({activeTab, onTabChange}: MailSelectProps) => {
                   'border-none px-0',
                   'text-body-l-b! lg:text-h5!'
                 )}
+                wrapperClassName='h-5.5 lg:h-10'
                 onClick={() => onTabChange(tab)}
               />
             </li>

--- a/apps/recruit/src/app/admin/(with-sidebar)/results/_components/mail-manage/ManageResultMail.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/results/_components/mail-manage/ManageResultMail.tsx
@@ -12,7 +12,7 @@ export const ManageResultMail = ({generationId}: ManageResultMailProps) => {
   const [activeTab, setActiveTab] = useState('합격자 메일');
 
   return (
-    <div className='flex flex-col gap-3.5'>
+    <div className='flex flex-col gap-2.5 lg:gap-3.5'>
       <MailSelect activeTab={activeTab} onTabChange={setActiveTab} />
       <ManageMail
         key={activeTab}

--- a/apps/recruit/src/app/admin/(with-sidebar)/results/_components/mail-manage/ManageResultMail.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/results/_components/mail-manage/ManageResultMail.tsx
@@ -15,7 +15,6 @@ export const ManageResultMail = ({generationId}: ManageResultMailProps) => {
     <div className='flex flex-col gap-2.5 lg:gap-3.5'>
       <MailSelect activeTab={activeTab} onTabChange={setActiveTab} />
       <ManageMail
-        key={activeTab}
         mailType={activeTab}
         generationId={generationId}
         alwaysAble={true}

--- a/apps/recruit/src/app/admin/(with-sidebar)/results/_components/result-manage/ManageResult.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/results/_components/result-manage/ManageResult.tsx
@@ -35,8 +35,10 @@ export const ManageResult = ({
     );
 
   return (
-    <div className='flex w-full flex-col gap-3.5'>
-      <h2 className='text-h4 text-neutral-800'>합격자 관리</h2>
+    <div className='flex w-full flex-col gap-2.5 lg:gap-3.5'>
+      <h2 className='text-h5 lg:text-h4 px-2.5 font-bold text-neutral-800 lg:px-0'>
+        합격자 관리
+      </h2>
       <GenerationDropdown
         generation={generation}
         generations={generationList}

--- a/apps/recruit/src/app/admin/(with-sidebar)/results/_components/result-manage/ManageResult.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/results/_components/result-manage/ManageResult.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import {useAdminPassStatusQuery} from '@/hooks/queries/useAdminResult.query';
-
 import {GenerationDropdown} from '@/components/dropdown/GenerationDropdown';
 import {Spinner} from '@repo/ui/components/spinner/Spinner';
 import {useGenerationStore} from '@/store/useGenerationStore';

--- a/apps/recruit/src/app/admin/(with-sidebar)/results/_components/result-manage/ManageResult.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/results/_components/result-manage/ManageResult.tsx
@@ -4,7 +4,6 @@ import {useAdminPassStatusQuery} from '@/hooks/queries/useAdminResult.query';
 
 import {GenerationDropdown} from '@/components/dropdown/GenerationDropdown';
 import {Spinner} from '@repo/ui/components/spinner/Spinner';
-import {STATUS_LABEL_MAP} from '@/constants/admin/admin-result';
 import {useGenerationStore} from '@/store/useGenerationStore';
 import {ResultTable} from '@/app/admin/(with-sidebar)/results/_components/result-manage/ResultTable';
 
@@ -20,12 +19,6 @@ export const ManageResult = ({
   const {data, isLoading} = useAdminPassStatusQuery(generation);
   const {generations} = useGenerationStore();
   const generationList = generations.map((g) => String(g.generationId));
-
-  const tableData =
-    data?.map((item) => ({
-      status: STATUS_LABEL_MAP[item.passStatus],
-      ...item.counts,
-    })) || [];
 
   if (isLoading)
     return (
@@ -44,7 +37,7 @@ export const ManageResult = ({
         generations={generationList}
         onSelect={onGenerationChange}
       />
-      <ResultTable data={tableData} />
+      <ResultTable data={data || []} />
     </div>
   );
 };

--- a/apps/recruit/src/app/admin/(with-sidebar)/results/_components/result-manage/ResultTable.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/results/_components/result-manage/ResultTable.tsx
@@ -1,4 +1,4 @@
-import {RESULT_PARTS} from '@/constants/admin/admin-result';
+import {RESULT_PARTS, STATUS_LABEL_MAP} from '@/constants/admin/admin-result';
 import {ResultSummaryData} from '@/schemas/admin/admin-result.type';
 
 interface ResultTableProps {
@@ -8,6 +8,20 @@ interface ResultTableProps {
 export const ResultTable = ({data}: ResultTableProps) => {
   const totalColumnCount = RESULT_PARTS.length + 1;
   const columnWidth = `${100 / totalColumnCount}%`;
+
+  const ORDER: ResultSummaryData['passStatus'][] = [
+    'PASS',
+    'FAIL',
+    'WAITLISTED',
+  ];
+
+  const processedData = ORDER.map((statusKey) => {
+    const target = data.find((d) => d.passStatus === statusKey);
+    return {
+      statusLabel: STATUS_LABEL_MAP[statusKey],
+      counts: target?.counts || {ALL: 0, PM: 0, DE: 0, FE: 0, BE: 0},
+    };
+  });
 
   return (
     <div className='overflow-x-auto'>
@@ -33,16 +47,16 @@ export const ResultTable = ({data}: ResultTableProps) => {
           </tr>
         </thead>
         <tbody className='divide-y divide-neutral-50 bg-neutral-50'>
-          {data.map((row, index) => (
+          {processedData.map((row, index) => (
             <tr key={index} className='bg-neutral-50'>
               <td className='lg:text-body-l-sb text-body-m px-1 py-[11.5px] font-bold whitespace-nowrap text-neutral-600 lg:px-5.5 lg:font-semibold'>
-                {row.status}
+                {row.statusLabel}
               </td>
               {RESULT_PARTS.map((part) => (
                 <td
                   key={part.value}
                   className='text-body-l-sb text-neutral-500'>
-                  {row[part.value] ?? 0}
+                  {row.counts[part.value] ?? 0}
                 </td>
               ))}
             </tr>

--- a/apps/recruit/src/app/admin/(with-sidebar)/results/_components/result-manage/ResultTable.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/results/_components/result-manage/ResultTable.tsx
@@ -11,7 +11,7 @@ export const ResultTable = ({data}: ResultTableProps) => {
 
   return (
     <div className='overflow-x-auto'>
-      <table className='w-full table-fixed bg-white text-center'>
+      <table className='w-full table-fixed bg-neutral-200 text-center'>
         <colgroup>
           <col style={{width: columnWidth}} />
           {RESULT_PARTS.map((part) => (
@@ -19,14 +19,14 @@ export const ResultTable = ({data}: ResultTableProps) => {
           ))}
         </colgroup>
         <thead>
-          <tr className='text-body-l bg-neutral-200 font-semibold'>
-            <th className='px-5.5 py-[11.5px] whitespace-nowrap text-neutral-600'>
+          <tr className='lg:text-body-l-sb text-body-m bg-neutral-200 font-bold'>
+            <th className='px-[3.25px] py-3 whitespace-nowrap text-neutral-600 lg:px-5.5 lg:py-[11.5px]'>
               합격 여부
             </th>
             {RESULT_PARTS.map((part) => (
               <th
                 key={part.value}
-                className='whitespace-nowrap text-neutral-600'>
+                className='px-[3.25px] py-3 whitespace-nowrap text-neutral-600 lg:px-5.5 lg:py-[11.5px]'>
                 {part.label}
               </th>
             ))}
@@ -34,14 +34,14 @@ export const ResultTable = ({data}: ResultTableProps) => {
         </thead>
         <tbody className='divide-y divide-neutral-50 bg-neutral-50'>
           {data.map((row, index) => (
-            <tr key={index}>
-              <td className='text-body-l px-5.5 py-[11.5px] font-semibold whitespace-nowrap text-neutral-600'>
+            <tr key={index} className='bg-neutral-50'>
+              <td className='lg:text-body-l-sb text-body-m px-1 py-[11.5px] font-bold whitespace-nowrap text-neutral-600 lg:px-5.5 lg:font-semibold'>
                 {row.status}
               </td>
               {RESULT_PARTS.map((part) => (
                 <td
                   key={part.value}
-                  className='text-body-l font-semibold text-neutral-500'>
+                  className='text-body-l-sb text-neutral-500'>
                   {row[part.value] ?? 0}
                 </td>
               ))}

--- a/apps/recruit/src/app/admin/(with-sidebar)/results/page.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/results/page.tsx
@@ -4,7 +4,7 @@ import {SuspenseWrapper} from '@/components/wrappers/SuspenseWrapper';
 
 export default function AdminResultsPage() {
   return (
-    <section className='flex min-w-275 flex-col items-center justify-center p-12.5'>
+    <section className='flex flex-col items-center justify-center lg:p-12.5'>
       <RecruitmentInitializer>
         <SuspenseWrapper>
           <ResultsContainer />

--- a/apps/recruit/src/components/dropdown/GenerationDropdown.tsx
+++ b/apps/recruit/src/components/dropdown/GenerationDropdown.tsx
@@ -42,7 +42,7 @@ export const GenerationDropdown = ({
           onClick={handleToggle}
           disabled={disabled}
           className={clsx(
-            'shadow-default text-body-l flex items-center gap-2 rounded-[30px] px-5 py-2',
+            'shadow-default text-body-l flex items-center gap-2 rounded-[30px] px-3.75 py-1.5 lg:px-5 lg:py-2',
             disabled
               ? 'cursor-not-allowed bg-neutral-100 text-neutral-400'
               : 'bg-white text-neutral-700'

--- a/apps/recruit/src/constants/admin/admin-result.ts
+++ b/apps/recruit/src/constants/admin/admin-result.ts
@@ -8,6 +8,6 @@ export const RESULT_PARTS = [
 
 export const STATUS_LABEL_MAP = {
   PASS: '합격',
-  WAITLISTED: '예비 합격',
+  WAITLISTED: '예비합격',
   FAIL: '불합격',
 } as const;

--- a/apps/recruit/src/schemas/admin/admin-result.type.ts
+++ b/apps/recruit/src/schemas/admin/admin-result.type.ts
@@ -1,10 +1,9 @@
 import {RESULT_PARTS, STATUS_LABEL_MAP} from '@/constants/admin/admin-result';
 
 export type ResultPartValue = (typeof RESULT_PARTS)[number]['value'];
-type StatusLabel = (typeof STATUS_LABEL_MAP)[keyof typeof STATUS_LABEL_MAP];
-
-export interface ResultSummaryData extends Record<ResultPartValue, number> {
-  status: StatusLabel;
-}
-
 export type PassStatus = keyof typeof STATUS_LABEL_MAP;
+
+export interface ResultSummaryData {
+  passStatus: PassStatus;
+  counts: Record<ResultPartValue, number>;
+}


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->

close #322

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->

## 합격자 관리 페이지 수정 (리팩토링 & 오류 해결)
합격자 관리 페이지의 통계 테이블 정렬 순서를 고정하고 메일 관리 탭 전환 시 발생하던 `전송 중` 상태 오표기 문제를 해결했습니다.
<br>

### 합격자 관리 상단 통계 테이블 정렬 순서 수정
서버에서 내려주는 데이터 순서와 상관없이 디자인을 완전히 반영하기 위해 테이블 행 순서를 강제로 고정했습니다.
- 서버에서 내려주는 순서(기존순서): 합격 -> 예비 합격 -> 불합격
- 고정 순서: 합격 -> 불합격 -> 예비 합격

기존에는 서버 응답 순서 그대로 예비 합격이 불합격보다 먼저 표시되었는데, 디자인 완전 반영을 위해 `ORDER` 배열 기반 로직을 추가했습니다.

<br>

### 메일 관리 탭 전환 시 뜨던 `전송 중` UI 버그 수정
합격/불합격/예비합격 메일 탭을 이동할 때, 실제 전송 중이 아님에도 버튼에 `전송 중` 문구가 잠깐 뜨면서 리프레시 버튼이 돌아가던 현상을 수정했습니다.

- 원인: ManageMail 컴포넌트에 `key={activeTab}`이 설정되어 있어 탭 이동 시마다 컴포넌트가 언마운트 후 재마운트되었고, 이 과정에서 데이터를 새로 불러오는 `isFetching` 상태를 전송 중으로 잘못 판단하여 발생했습니다!

- 해결: ManageMail의 key 속성을 제거했습니다. (불필요한 초기화 제거)

<br>

## 합격자 관리 페이지 모바일 UI 구현
합격자 관리 전체 페이지 모바일뷰를 구현했습니다! (lg 기준)
상단의 합격자관리 통계 테이블(`ResultTable.tsx`), 중간의 메일 종류 선택 탭(`MailSelect`)의 모바일뷰를 추가했어요.

> 하단의 메일 관리 부분 컴포넌트는 모집 활성화 - 지원알림메일에서 사용되는 컴포넌트와 동일해서(=같은 컴포넌트) 이전 pr에서 같이 구현해두었기 때문에 이 pr에서는 따로 확인하시지 않아도 될 것 같습니다



<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->


https://github.com/user-attachments/assets/1ff117f7-2221-43e7-b2f5-58aefbbf791a



<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 합격자 관리 테이블 순서 합격 > 불합격 > 예비 순으로 나오는지 확인
- [ ] 메일 관리 탭 이동 시 전송 중으로 렌더링되지않는지 확인
- [ ] 합격자관리 페이지 모바일 UI 확인

<br>

