### PR TITLE
[UI]: 리쿠르팅 어드민 지원서 열람 반응형 구현

### DIFF
--- a/apps/recruit/src/app/admin/(no-sidebar)/applications/[id]/_containers/AdminApplicationContainer.tsx
+++ b/apps/recruit/src/app/admin/(no-sidebar)/applications/[id]/_containers/AdminApplicationContainer.tsx
@@ -87,7 +87,7 @@ export const AdminApplicationContainer = () => {
 
         {step === 2 && (
           <div className='flex flex-col gap-5'>
-            <label className='sm:text-h3 text-h5-b text-primary font-bold'>
+            <label className='lg:text-h3 text-h5-b text-primary font-bold'>
               {APPLICATIONS_PART_TABS.find(
                 (tab) => tab.value === basicInfo.data.applicationPartType
               )?.label ?? '-'}{' '}
@@ -108,7 +108,7 @@ export const AdminApplicationContainer = () => {
 
         {step === 3 && (
           <div className='flex flex-col gap-5'>
-            <label className='sm:text-h3 text-h5-b font-bold text-neutral-800'>
+            <label className='lg:text-h3 text-h5-b font-bold text-neutral-800'>
               기타 질문
             </label>
             <div className='flex justify-center'>

--- a/apps/recruit/src/app/admin/(no-sidebar)/applications/[id]/_containers/AdminApplicationEvaluationContainer.tsx
+++ b/apps/recruit/src/app/admin/(no-sidebar)/applications/[id]/_containers/AdminApplicationEvaluationContainer.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import {EvaluationTextarea} from '@/app/admin/(no-sidebar)/applications/[id]/_components/EvaluationTextArea';
 import {EVALUATOR_TABS} from '@/constants/admin/admin-applications';
 import {useAdminApplicationEvaluation} from '@/hooks/queries/useAdminApplication.query';
 import {EvaluatorType} from '@/schemas/admin/admin-application.schema';
 import {useRouter, useSearchParams} from 'next/navigation';
-import {useEffect, useRef} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import clsx from 'clsx';
+import {useDebounce} from '@/hooks/useDebounce';
+import {usePostAdminApplicationEvaluation} from '@/hooks/mutations/useAdminApplication.mutation';
 
 const DEFAULT_EVALUATOR: EvaluatorType = 'STAFF1';
 
@@ -23,6 +24,21 @@ export const AdminApplicationEvaluationContainer = ({
     (searchParams.get('evaluator') as EvaluatorType) ?? DEFAULT_EVALUATOR;
 
   const evaluatorRef = useRef<EvaluatorType>(evaluator);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [draft, setDraft] = useState<string | null>(null);
+  const debouncedDraft = useDebounce(draft, 500);
+
+  const {mutate} = usePostAdminApplicationEvaluation(applicationId);
+
+  const {data: evaluation} = useAdminApplicationEvaluation({
+    applicationId,
+    evaluatorType: evaluator,
+  });
+
+  // 탭 변경 시 draft 초기화
+  useEffect(() => {
+    setDraft(null);
+  }, [evaluator]);
 
   useEffect(() => {
     const reviewer = searchParams.get('evaluator');
@@ -37,20 +53,48 @@ export const AdminApplicationEvaluationContainer = ({
     evaluatorRef.current = evaluator;
   }, [evaluator]);
 
-  const {data: evaluation} = useAdminApplicationEvaluation({
-    applicationId,
-    evaluatorType: evaluator,
-  });
-
   const handleEvaluatorClick = (reviewer: EvaluatorType) => {
     const params = new URLSearchParams(searchParams.toString());
     params.set('evaluator', reviewer);
     router.push(`?${params.toString()}`, {scroll: false});
   };
 
+  const handleResizeHeight = () => {
+    const textarea = textareaRef.current;
+    if (textarea) {
+      textarea.style.height = 'auto';
+      textarea.style.height = `${textarea.scrollHeight}px`;
+    }
+  };
+
+  const displayValue = draft ?? evaluation?.data.comment ?? '';
+
+  useEffect(() => {
+    handleResizeHeight();
+  }, [displayValue]);
+
+  useEffect(() => {
+    // 아직 입력이 없거나 초기 상태면 중단
+    if (draft === null || debouncedDraft === null) return;
+    if (!evaluation) return;
+
+    const serverComment = evaluation.data.comment ?? '';
+
+    // 서버 데이터와 동일하면 API 호출 방지
+    if (debouncedDraft === serverComment) return;
+
+    mutate({
+      applicationId,
+      body: {
+        evaluatorType: evaluator,
+        comment: debouncedDraft,
+      },
+    });
+  }, [debouncedDraft, evaluation, evaluator, applicationId, mutate]);
+
   return (
     <div className='flex w-full flex-col gap-2.5'>
-      <div className='flex gap-5 sm:gap-10'>
+      <div className='flex gap-5 lg:gap-10'>
         {EVALUATOR_TABS.map(({label, value}) => {
           const isActive = evaluator === value;
           return (
@@ -58,8 +102,8 @@ export const AdminApplicationEvaluationContainer = ({
               key={value}
               onClick={() => handleEvaluatorClick(value)}
               className={clsx(
-                'flex h-10 min-w-12.5 items-center justify-center transition-colors',
-                'text-body-m sm:text-h5',
+                'flex min-w-12.5 items-center justify-center transition-colors lg:h-10',
+                'text-body-m lg:text-h5',
                 isActive
                   ? 'font-bold text-neutral-800'
                   : 'font-medium text-neutral-400',
@@ -71,11 +115,12 @@ export const AdminApplicationEvaluationContainer = ({
         })}
       </div>
 
-      <EvaluationTextarea
-        key={evaluator}
-        evaluator={evaluator}
-        evaluation={evaluation}
-        applicationId={applicationId}
+      <textarea
+        ref={textareaRef}
+        value={displayValue}
+        onChange={(e) => setDraft(e.target.value)}
+        placeholder='면접 질문 및 서류평가에 대해 자유롭게 작성해주세요.'
+        className='lg:text-h5 text-body-l min-h-35 w-full resize-none overflow-hidden rounded-[10px] border-[1.5px] border-neutral-200 bg-white p-5 outline-none placeholder:text-neutral-600'
       />
     </div>
   );

--- a/apps/recruit/src/app/admin/(no-sidebar)/applications/[id]/layout.tsx
+++ b/apps/recruit/src/app/admin/(no-sidebar)/applications/[id]/layout.tsx
@@ -7,7 +7,7 @@ export default function AdminNoSideBarLayout({
 }>) {
   return (
     <ProtectedRoute requireRole='STAFF'>
-      <section className='flex min-h-screen w-full flex-row items-center justify-center bg-white px-[25px] py-10'>
+      <section className='flex min-h-screen w-full flex-row items-center justify-center bg-white px-6 py-7.5 lg:px-6.25 lg:py-10'>
         <main className='max-w-275 min-w-0 flex-1'>{children}</main>
       </section>
     </ProtectedRoute>

--- a/apps/recruit/src/app/admin/(with-sidebar)/applications/_components/tab/AdminApplicationsTabPart.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/applications/_components/tab/AdminApplicationsTabPart.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 
 interface AdminApplicationsTabPartProps {
+  value?: string;
   partName?: string;
   applyNumber?: number;
   isActive?: boolean;
@@ -10,6 +11,7 @@ interface AdminApplicationsTabPartProps {
 }
 
 export const AdminApplicationsTabPart = ({
+  value,
   partName,
   applyNumber,
   isActive = false,
@@ -36,7 +38,10 @@ export const AdminApplicationsTabPart = ({
         'border-b-2 transition-colors',
         isActive ? 'border-primary' : 'border-transparent'
       )}>
-      <span className='text-body-m font-bold text-neutral-800'>{partName}</span>
+      <span className='text-body-m hidden font-bold text-neutral-800 lg:block'>
+        {partName}
+      </span>
+      <span className='text-h5 text-neutral-800 lg:hidden'>{value}</span>
 
       <span
         aria-hidden='true'

--- a/apps/recruit/src/app/admin/(with-sidebar)/applications/_components/table/AdminApplicationsTableView.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/applications/_components/table/AdminApplicationsTableView.tsx
@@ -10,7 +10,6 @@ import {ROUTES} from '@/constants/routes';
 import DefaultFilterIcon from '@repo/ui/assets/icons/filter-default.svg';
 import FinishFilterIcon from '@repo/ui/assets/icons/filter-finish.svg';
 import DownArrowIcon from '@/assets/arrow/down-arrow.svg';
-
 import clsx from 'clsx';
 import {
   ApplicantType,
@@ -69,10 +68,19 @@ export const AdminApplicationsTableView = ({
 
             const isResultColumn = col.key === 'result';
 
+            {
+              /** 모바일뷰에서 전화번호, 제출일자 숨김 처리 */
+            }
+            const isHiddenOnMobile =
+              col.key === 'phone' || col.key === 'submitDate';
+
             return (
               <th
                 key={col.key}
-                className='text-body-l px-3 py-4 text-center align-middle font-semibold text-neutral-600'>
+                className={clsx(
+                  'text-body-l bg-neutral-200 py-4 text-center align-middle font-semibold text-neutral-600 lg:px-3',
+                  isHiddenOnMobile && 'hidden lg:table-cell'
+                )}>
                 <div className='flex items-center justify-center gap-2.5'>
                   <span>{col.label}</span>
 
@@ -92,7 +100,7 @@ export const AdminApplicationsTableView = ({
                       </button>
 
                       {isFilterOpen && (
-                        <div className='absolute top-full left-0 z-50 mt-2 w-27 -translate-x-3/4'>
+                        <div className='absolute top-full left-0 z-50 mt-4 w-27 -translate-x-3/4 lg:mt-2'>
                           <CheckboxFilter
                             options={RESULT_OPTIONS}
                             selected={selectedResults}
@@ -131,7 +139,7 @@ export const AdminApplicationsTableView = ({
           <tr
             key={app.applicationId}
             className='text-body-l font-semibold text-neutral-600'>
-            <td className='flex items-center justify-center px-3 py-4'>
+            <td className='truncate px-3 py-4 text-center'>
               <a
                 href={`${ROUTES.ADMIN_APPLICATIONS}/${app.applicationId}?generationId=${generationId}`}
                 target='_blank'
@@ -151,10 +159,10 @@ export const AdminApplicationsTableView = ({
             <td className='truncate px-3 py-4'>
               <p className='text-center'>{app.university}</p>
             </td>
-            <td className='truncate px-3 py-4'>
+            <td className='hidden truncate px-3 py-4 lg:table-cell'>
               <p className='text-center'>{app.phoneNumber}</p>
             </td>
-            <td className='truncate px-3 py-4'>
+            <td className='hidden truncate px-3 py-4 lg:table-cell'>
               <p className='text-center'>{formatKoreanDate(app.submittedAt)}</p>
             </td>
             <td className='px-3 py-4'>

--- a/apps/recruit/src/app/admin/(with-sidebar)/applications/_components/table/AdminApplicationsTableView.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/applications/_components/table/AdminApplicationsTableView.tsx
@@ -68,9 +68,8 @@ export const AdminApplicationsTableView = ({
 
             const isResultColumn = col.key === 'result';
 
-            {
-              /** 모바일뷰에서 전화번호, 제출일자 숨김 처리 */
-            }
+            // 모바일뷰에서 전화번호, 제출일자 숨김 처리
+
             const isHiddenOnMobile =
               col.key === 'phone' || col.key === 'submitDate';
 

--- a/apps/recruit/src/app/admin/(with-sidebar)/applications/_containers/AdminApplicationsContainer.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/applications/_containers/AdminApplicationsContainer.tsx
@@ -2,15 +2,15 @@
 
 import {AdminApplicationsTableContainer} from '@/app/admin/(with-sidebar)/applications/_containers/AdminApplicationsTableContainer';
 import {AdminApplicationsTabContainer} from '@/app/admin/(with-sidebar)/applications/_containers/AdminApplicationsTabContainer';
-
 import {GetAdminApplicationsParamsSchema} from '@/schemas/admin/admin-applications.schema';
 import {useSearchParams} from 'next/navigation';
 import {useAdminApplicationsQuery} from '@/hooks/queries/useAdminApplications.query';
 import {useEffect} from 'react';
-import {AdminApplicationsInformation} from '@/app/admin/(with-sidebar)/applications/_components/info/AdminApplicationsInformation';
 import {Spinner} from '@repo/ui/components/spinner/Spinner';
 import {useGenerationStore} from '@/store/useGenerationStore';
 import {useAdminGenerationsQuery} from '@/hooks/queries/useAdminGeneration.query';
+import {AdminApplicationsDesktopInformationContainer} from '@/app/admin/(with-sidebar)/applications/_desktop/AdminApplicationsDesktopInformationContainer';
+import {AdminApplicationsMobileInformationContainer} from '@/app/admin/(with-sidebar)/applications/_mobile/AdminApplicationsMobileInformationContainer';
 
 export const AdminApplicationsContainer = () => {
   const searchParams = useSearchParams();
@@ -61,14 +61,21 @@ export const AdminApplicationsContainer = () => {
   if (isInitialLoading) {
     return (
       <div className='flex h-[calc(100vh-200px)] items-center justify-center'>
-        <Spinner />
+        <Spinner size='sm' className='block lg:hidden' />
+        <Spinner size='lg' className='hidden lg:block' />
       </div>
     );
   }
 
   return (
     <div className='flex flex-col gap-7.25'>
-      <AdminApplicationsInformation
+      <AdminApplicationsDesktopInformationContainer
+        generation={currentGeneration}
+        generations={generationList}
+        recruitmentPeriod={data?.data.recruitmentPeriodResponse}
+        isLoading={isInitialLoading}
+      />
+      <AdminApplicationsMobileInformationContainer
         generation={currentGeneration}
         generations={generationList}
         recruitmentPeriod={data?.data.recruitmentPeriodResponse}

--- a/apps/recruit/src/app/admin/(with-sidebar)/applications/_containers/AdminApplicationsContainer.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/applications/_containers/AdminApplicationsContainer.tsx
@@ -16,7 +16,8 @@ export const AdminApplicationsContainer = () => {
   const searchParams = useSearchParams();
 
   /** 기수 목록 조회 */
-  const {data: generationsData} = useAdminGenerationsQuery();
+  const {data: generationsData, isLoading: isGenerationLoading} =
+    useAdminGenerationsQuery();
   const {setGenerations, generations} = useGenerationStore();
   const generationList = generations.map((g) => String(g.generationId));
   const currentGeneration =
@@ -47,15 +48,7 @@ export const AdminApplicationsContainer = () => {
 
   const {data, isLoading, isFetching} = useAdminApplicationsQuery(filter);
 
-  if (!currentGeneration) {
-    return (
-      <div className='flex h-100 w-full items-center justify-center'>
-        <p className='text-neutral-500'>등록된 기수 정보가 없습니다.</p>
-      </div>
-    );
-  }
-
-  const isInitialLoading = isLoading && !data;
+  const isInitialLoading = isGenerationLoading && isLoading && !data;
   const isRefreshing = isFetching && !!data;
 
   if (isInitialLoading) {
@@ -63,6 +56,14 @@ export const AdminApplicationsContainer = () => {
       <div className='flex h-[calc(100vh-200px)] items-center justify-center'>
         <Spinner size='sm' className='block lg:hidden' />
         <Spinner size='lg' className='hidden lg:block' />
+      </div>
+    );
+  }
+
+  if (!currentGeneration) {
+    return (
+      <div className='flex h-100 w-full items-center justify-center'>
+        <p className='text-neutral-500'>등록된 기수 정보가 없습니다.</p>
       </div>
     );
   }

--- a/apps/recruit/src/app/admin/(with-sidebar)/applications/_containers/AdminApplicationsTabContainer.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/applications/_containers/AdminApplicationsTabContainer.tsx
@@ -53,7 +53,10 @@ export const AdminApplicationsTabContainer = ({
   };
 
   return (
-    <div className='flex gap-7.5' role='tablist' aria-label='지원 파트 선택'>
+    <div
+      className='flex gap-5 lg:gap-7.5'
+      role='tablist'
+      aria-label='지원 파트 선택'>
       {APPLICATIONS_PART_TABS.map(({label, value}, index) => {
         const countKey = PART_COUNT_MAP[value];
         const applyNumber = summary?.[countKey];
@@ -61,6 +64,7 @@ export const AdminApplicationsTabContainer = ({
         return (
           <AdminApplicationsTabPart
             key={value}
+            value={value}
             partName={label}
             applyNumber={isLoading ? undefined : applyNumber}
             isActive={isActive}

--- a/apps/recruit/src/app/admin/(with-sidebar)/applications/_containers/AdminApplicationsTabContainer.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/applications/_containers/AdminApplicationsTabContainer.tsx
@@ -54,7 +54,7 @@ export const AdminApplicationsTabContainer = ({
 
   return (
     <div
-      className='flex gap-5 lg:gap-7.5'
+      className='flex gap-3.5 lg:gap-7.5'
       role='tablist'
       aria-label='지원 파트 선택'>
       {APPLICATIONS_PART_TABS.map(({label, value}, index) => {

--- a/apps/recruit/src/app/admin/(with-sidebar)/applications/_containers/AdminApplicationsTableContainer.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/applications/_containers/AdminApplicationsTableContainer.tsx
@@ -139,7 +139,7 @@ export const AdminApplicationsTableContainer = ({
 
       {/* 로딩 끝 + 데이터 없음 */}
       {isEmpty && (
-        <div className='text-body-l flex w-full justify-center pt-56.5 font-normal'>
+        <div className='text-body-l flex w-full justify-center pt-30 font-normal text-neutral-500 lg:pt-56.5'>
           아직 지원자가 없습니다.
         </div>
       )}

--- a/apps/recruit/src/app/admin/(with-sidebar)/applications/_containers/AdminApplicationsTableContainer.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/applications/_containers/AdminApplicationsTableContainer.tsx
@@ -98,7 +98,9 @@ export const AdminApplicationsTableContainer = ({
             {/* 쿼리 갱신 로딩 */}
             {isLoading && (
               <div className='absolute inset-0 z-10 flex items-center justify-center'>
-                <Spinner size='lg' />
+                <Spinner size='sm' className='block lg:hidden' />
+
+                <Spinner size='lg' className='hidden lg:block' />
               </div>
             )}
 

--- a/apps/recruit/src/app/admin/(with-sidebar)/applications/_desktop/AdminApplicationsDesktopInformationContainer.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/applications/_desktop/AdminApplicationsDesktopInformationContainer.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import SearchIcon from '@repo/ui/assets/icons/search.svg';
+import {GenerationDropdown} from '@/components/dropdown/GenerationDropdown';
+import {Spinner} from '@repo/ui/components/spinner/Spinner';
+import {RecruitmentPeriodSchemaType} from '@/schemas/admin/admin-applications.schema';
+import {useRouter, useSearchParams} from 'next/navigation';
+import {useState} from 'react';
+
+interface AdminApplicationsDesktopInformationContainerProps {
+  generation: string;
+  generations: string[];
+  recruitmentPeriod?: RecruitmentPeriodSchemaType;
+  isLoading: boolean;
+}
+
+export const AdminApplicationsDesktopInformationContainer = ({
+  generation,
+  generations,
+  recruitmentPeriod,
+  isLoading,
+}: AdminApplicationsDesktopInformationContainerProps) => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const [keyword, setKeyword] = useState<string>(
+    searchParams.get('keyword') ?? ''
+  );
+
+  const handleSearch = () => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    if (keyword.trim()) {
+      params.set('keyword', keyword);
+    } else {
+      params.delete('keyword');
+    }
+
+    params.set('page', '1');
+    router.push(`?${params.toString()}`, {scroll: false});
+  };
+
+  const handleGenerationSelect = (generation: string) => {
+    if (isLoading) return;
+    const params = new URLSearchParams(searchParams.toString());
+
+    params.set('generationId', generation);
+    params.set('page', '1');
+
+    router.push(`?${params.toString()}`, {scroll: false});
+  };
+
+  return (
+    <div
+      className='hidden w-full justify-between gap-50 gap-y-4 rounded-[10px] bg-neutral-100 p-4 lg:flex'
+      aria-busy={isLoading}>
+      <div className='flex flex-row gap-7.25'>
+        <div
+          className='flex flex-col gap-4'
+          role='group'
+          aria-labelledby='generation-label'>
+          <label id='generation-label' className='text-body-l text-neutral-600'>
+            기수 정보
+          </label>
+          <GenerationDropdown
+            generation={generation}
+            generations={generations}
+            onSelect={handleGenerationSelect}
+            disabled={isLoading}
+          />
+        </div>
+        <div
+          role='group'
+          aria-labelledby='recruitment-period-label'
+          className='flex flex-col gap-4'>
+          <p
+            id='recruitment-period-label'
+            className='text-body-l text-neutral-600'>
+            지원기간
+          </p>
+
+          <div className='text-body-l flex flex-row gap-2.5 font-normal'>
+            {isLoading ? (
+              <Spinner size='sm' />
+            ) : (
+              <>
+                <p className='rounded-[10px] bg-neutral-50 px-8 py-1.75 text-neutral-800'>
+                  {recruitmentPeriod?.recruitmentStart?.slice(0, 10)}
+                </p>
+                <p className='rounded-[10px] bg-neutral-50 px-8 py-1.75 text-neutral-800'>
+                  {recruitmentPeriod?.recruitmentEnd?.slice(0, 10)}
+                </p>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+      <div className='flex flex-1 items-end justify-end'>
+        <form
+          role='search'
+          aria-label='지원자 검색'
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSearch();
+          }}
+          className='flex h-12.5 w-full flex-row items-center gap-2.5 rounded-[10px] bg-white px-4 py-2.75'>
+          <SearchIcon
+            aria-hidden='true'
+            className='h-4 w-4 text-neutral-600'
+            focusable='false'
+          />
+          <input
+            type='search'
+            placeholder='이름 혹은 학교 검색'
+            aria-label='지원자 이름 또는 학교 검색'
+            value={keyword}
+            onChange={(e) => setKeyword(e.target.value)}
+            disabled={isLoading}
+            className='text-body-l w-full font-normal outline-none placeholder:text-neutral-600'
+          />
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/apps/recruit/src/app/admin/(with-sidebar)/applications/_mobile/AdminApplicationsMobileInformationContainer.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/applications/_mobile/AdminApplicationsMobileInformationContainer.tsx
@@ -76,10 +76,10 @@ export const AdminApplicationsMobileInformationContainer = ({
               ) : (
                 <>
                   <p className='rounded-[10px] bg-neutral-50 px-2.5 py-1.25'>
-                    {recruitmentPeriod?.recruitmentStart?.slice(0, 10)}
+                    {recruitmentPeriod?.recruitmentStart?.slice(0, 10) ?? '-'}
                   </p>
                   <p className='rounded-[10px] bg-neutral-50 px-2.5 py-1.25'>
-                    {recruitmentPeriod?.recruitmentEnd?.slice(0, 10)}
+                    {recruitmentPeriod?.recruitmentEnd?.slice(0, 10) ?? '-'}
                   </p>
                 </>
               )}

--- a/apps/recruit/src/app/admin/(with-sidebar)/applications/_mobile/AdminApplicationsMobileInformationContainer.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/applications/_mobile/AdminApplicationsMobileInformationContainer.tsx
@@ -53,7 +53,7 @@ export const AdminApplicationsMobileInformationContainer = ({
   return (
     <aside className='flex flex-col gap-2.5 rounded-[10px] bg-neutral-100 px-5 py-3.25 lg:hidden'>
       <h2 className='text-body-l-b text-neutral-800'>활동 정보</h2>
-      <div className='flex flex-row justify-between gap-2.5'>
+      <div className='flex flex-row gap-2.5'>
         <div className='flex flex-col gap-2'>
           <p className='text-body-l flex flex-row gap-2.5 text-neutral-600'>
             기수 정보

--- a/apps/recruit/src/app/admin/(with-sidebar)/applications/_mobile/AdminApplicationsMobileInformationContainer.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/applications/_mobile/AdminApplicationsMobileInformationContainer.tsx
@@ -53,7 +53,7 @@ export const AdminApplicationsMobileInformationContainer = ({
   return (
     <aside className='flex flex-col gap-2.5 rounded-[10px] bg-neutral-100 px-5 py-3.25 lg:hidden'>
       <h2 className='text-body-l-b text-neutral-800'>활동 정보</h2>
-      <div className='flex flex-row gap-2.5'>
+      <div className='flex flex-row justify-between gap-2.5'>
         <div className='flex flex-col gap-2'>
           <p className='text-body-l flex flex-row gap-2.5 text-neutral-600'>
             기수 정보
@@ -63,6 +63,7 @@ export const AdminApplicationsMobileInformationContainer = ({
             generations={generations}
             onSelect={handleGenerationSelect}
             disabled={isLoading}
+            className='px-[9px] py-[6px]'
           />
         </div>
         <div className='flex flex-col gap-2'>

--- a/apps/recruit/src/app/admin/(with-sidebar)/applications/_mobile/AdminApplicationsMobileInformationContainer.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/applications/_mobile/AdminApplicationsMobileInformationContainer.tsx
@@ -7,19 +7,19 @@ import {RecruitmentPeriodSchemaType} from '@/schemas/admin/admin-applications.sc
 import {useRouter, useSearchParams} from 'next/navigation';
 import {useState} from 'react';
 
-interface AdminApplicationsInformationProps {
+interface AdminApplicationsMobileInformationContainerProps {
   generation: string;
   generations: string[];
   recruitmentPeriod?: RecruitmentPeriodSchemaType;
   isLoading: boolean;
 }
 
-export const AdminApplicationsInformation = ({
+export const AdminApplicationsMobileInformationContainer = ({
   generation,
   generations,
   recruitmentPeriod,
   isLoading,
-}: AdminApplicationsInformationProps) => {
+}: AdminApplicationsMobileInformationContainerProps) => {
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -51,17 +51,13 @@ export const AdminApplicationsInformation = ({
   };
 
   return (
-    <div
-      className='flex w-full justify-between gap-50 gap-y-4 rounded-[10px] bg-neutral-100 p-4'
-      aria-busy={isLoading}>
-      <div className='flex flex-row gap-7.25'>
-        <div
-          className='flex flex-col gap-4'
-          role='group'
-          aria-labelledby='generation-label'>
-          <label id='generation-label' className='text-body-l text-neutral-600'>
+    <aside className='flex flex-col gap-2.5 rounded-[10px] bg-neutral-100 px-5 py-3.25 lg:hidden'>
+      <h2 className='text-body-l-b text-neutral-800'>활동 정보</h2>
+      <div className='flex flex-row gap-2.5'>
+        <div className='flex flex-col gap-2'>
+          <p className='text-body-l flex flex-row gap-2.5 text-neutral-600'>
             기수 정보
-          </label>
+          </p>
           <GenerationDropdown
             generation={generation}
             generations={generations}
@@ -69,29 +65,25 @@ export const AdminApplicationsInformation = ({
             disabled={isLoading}
           />
         </div>
-        <div
-          role='group'
-          aria-labelledby='recruitment-period-label'
-          className='flex flex-col gap-4'>
-          <p
-            id='recruitment-period-label'
-            className='text-body-l text-neutral-600'>
-            지원기간
+        <div className='flex flex-col gap-2'>
+          <p className='text-body-l flex flex-row gap-2.5 text-neutral-600'>
+            활동 기간
           </p>
-
-          <div className='text-body-l flex flex-row gap-2.5 font-normal'>
-            {isLoading ? (
-              <Spinner size='sm' />
-            ) : (
-              <>
-                <p className='rounded-[10px] bg-neutral-50 px-8 py-1.75 text-neutral-800'>
-                  {recruitmentPeriod?.recruitmentStart?.slice(0, 10)}
-                </p>
-                <p className='rounded-[10px] bg-neutral-50 px-8 py-1.75 text-neutral-800'>
-                  {recruitmentPeriod?.recruitmentEnd?.slice(0, 10)}
-                </p>
-              </>
-            )}
+          <div className='flex flex-row'>
+            <div className='text-body-l flex flex-row gap-2 text-neutral-800'>
+              {isLoading ? (
+                <Spinner size='sm' />
+              ) : (
+                <>
+                  <p className='rounded-[10px] bg-neutral-50 px-2.5 py-1.25'>
+                    {recruitmentPeriod?.recruitmentStart?.slice(0, 10)}
+                  </p>
+                  <p className='rounded-[10px] bg-neutral-50 px-2.5 py-1.25'>
+                    {recruitmentPeriod?.recruitmentEnd?.slice(0, 10)}
+                  </p>
+                </>
+              )}
+            </div>
           </div>
         </div>
       </div>
@@ -103,7 +95,7 @@ export const AdminApplicationsInformation = ({
             e.preventDefault();
             handleSearch();
           }}
-          className='flex h-12.5 w-full flex-row items-center gap-2.5 rounded-[10px] bg-white px-4 py-2.75'>
+          className='flex h-10 w-full flex-row items-center gap-2.5 rounded-[10px] bg-white px-4 py-2.75'>
           <SearchIcon
             aria-hidden='true'
             className='h-4 w-4 text-neutral-600'
@@ -120,6 +112,6 @@ export const AdminApplicationsInformation = ({
           />
         </form>
       </div>
-    </div>
+    </aside>
   );
 };

--- a/apps/recruit/src/app/admin/(with-sidebar)/applications/page.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/applications/page.tsx
@@ -1,11 +1,11 @@
 import {AdminApplicationsContainer} from '@/app/admin/(with-sidebar)/applications/_containers/AdminApplicationsContainer';
 import {SuspenseWrapper} from '@/components/wrappers/SuspenseWrapper';
 
-export default function AdminApplicationPage() {
+export default function AdminApplicationsPage() {
   return (
-    <section className='flex flex-col p-12.5'>
-      <div className='flex flex-col gap-13.25 lg:min-w-275'>
-        <h1 className='text-h4'>지원서 열람</h1>
+    <section className='flex flex-col pt-2.5 lg:p-12.5'>
+      <div className='flex flex-col lg:min-w-275 lg:gap-13.25'>
+        <h1 className='text-h4 hidden lg:block'>지원서 열람</h1>
         <SuspenseWrapper>
           <AdminApplicationsContainer />
         </SuspenseWrapper>

--- a/apps/recruit/src/app/layout.tsx
+++ b/apps/recruit/src/app/layout.tsx
@@ -82,7 +82,7 @@ export default function RootLayout({children}: {children: React.ReactNode}) {
       lang='ko'
       className={`${pretendard.variable} ${roboto.variable} antialiased`}>
       {gtmId && <GoogleTagManager gtmId={gtmId} />}
-      <body className='flex min-h-screen w-full flex-col bg-black'>
+      <body className='flex min-h-screen w-full flex-col'>
         <Providers>
           <ConditionalAuthProvider>
             {gtmId && <GtmNoscript gtmId={gtmId} />}

--- a/packages/ui/src/components/dropdown/StatusDropdown.tsx
+++ b/packages/ui/src/components/dropdown/StatusDropdown.tsx
@@ -94,7 +94,7 @@ export const StatusDropdown = <T extends string>({
                 aria-selected={isSelected}
                 tabIndex={isSelected ? 0 : -1}
                 className={clsx(
-                  'cursor-pointer px-3 py-1.5 text-center',
+                  'cursor-pointer py-1.5 text-center lg:px-3',
                   isSelected ? 'text-primary' : 'hover:text-primary',
                   disabled && 'pointer-events-none opacity-60'
                 )}

--- a/packages/ui/src/components/form/FormFile.tsx
+++ b/packages/ui/src/components/form/FormFile.tsx
@@ -122,7 +122,7 @@ export const FormFile = forwardRef<HTMLInputElement, FormFileProps>(
             key={index}
             className={clsx(
               formFieldStyles.field,
-              'sm:text-h5 text-body-l mb-2 flex flex-row items-center rounded-[10px] px-[25px] py-4 text-black sm:px-10'
+              'lg:text-h5 text-body-l mb-2 flex flex-row items-center rounded-[10px] px-[25px] text-black lg:px-10 lg:py-4'
             )}>
             <FolderIcon />
             {props.readOnly ? (
@@ -150,7 +150,7 @@ export const FormFile = forwardRef<HTMLInputElement, FormFileProps>(
         {!props.readOnly && (
           <label
             className={clsx(
-              'sm:text-h5 text-body-l flex h-19 items-center justify-center rounded-[10px] bg-neutral-400 px-10 py-4 text-center text-white',
+              'lg:text-h5 text-body-l flex h-19 items-center justify-center rounded-[10px] bg-neutral-400 px-10 py-4 text-center text-white',
               isUploading ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'
             )}>
             <span>{isUploading ? '파일 업로드 중입니다' : placeholder}</span>


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->
close #317 

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->

리쿠르팅 어드민 지원서 조회, 지원서 열람 부분의 반응형 작업을 진행했습니다.

### 인포메이션 컨테이너화
기존 컴포넌트로 구현되어 있던 AdminApplicationInformation.tsx 컴포넌트를 컨테이너로 분리하고, 모바일용/데스크톱으로 나누어 구현해 뒀습니다. (비즈니스 로직 혼재되어 있는 문제 방지) 

### 지원서 테이블 관련
모바일용 디자인에는 전화번호, 제출일자 셀 부분이 포함되지 않은 디자인으로 구현되어 있어 헤더 셀과 컨텐츠 셀 내부에 hidden 속성을 적용해 두었습니다. 

### 지원 파트 탭 컨테이너 관련
모바일용 파트 탭 내부에 지원자 수까지 포함하기 위해 모바일용 뷰에서는 기존 한글 매핑 렌더링이 아닌 value를 그대로 렌더링하기 위하여 AdminApplicationsTabPart.tsx 컴포넌트 내부에 value props를 적용해 두었습니다. 

### 참고 사항 
제가 어드민 지원서 조회, 마이페이지 작업하면서 공통으로 사용되는 Form** 컴포넌트들에는 반응형을 적용해 둔 상태이니 해당 컴포넌트 사용하시는 상위 레이아웃에서 반응형 작업해 주시면 될 겁니다 

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->
![Animation](https://github.com/user-attachments/assets/eba01812-7a60-498d-b3d7-796ae56eb319)

<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 지원서 조회, 지원서 열람 반응형 체크
