### PR TITLE
[UI]: 관리자페이지 출석관리 모바일뷰 구현

### DIFF
--- a/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_components/PartTab.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_components/PartTab.tsx
@@ -25,12 +25,12 @@ export const PartTab = ({
       onKeyDown={onKeyDown}
       aria-label={partName}
       className={clsx(
-        'flex flex-row items-center gap-2 border-b-3 py-2.75 transition-colors duration-300',
+        'flex w-fit shrink-0 flex-row items-center gap-2 border-b-3 py-2.75 transition-colors duration-300',
         isActive
           ? 'border-primary text-neutral-800'
           : 'border-transparent text-neutral-500'
       )}>
-      <span className='text-h5'>{partName}</span>
+      <span className='text-h5 shrink-0'>{partName}</span>
     </button>
   );
 };

--- a/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_components/table/AdminAttendanceEntireTable.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_components/table/AdminAttendanceEntireTable.tsx
@@ -42,24 +42,22 @@ export const AdminAttendanceEntireTable = ({
             <tr
               key={row.memberInfo.memberId}
               className='text-body-m lg:text-body-l-sb text-neutral-600'>
-              <td className='truncate px-3 py-4 text-center'>
-                {row.memberInfo.name}
-              </td>
+              <td className='px-3 py-4 text-center'>{row.memberInfo.name}</td>
               <td className='truncate px-3 py-4 text-center'>
                 {MEMBER_POSITION_LABEL[
                   row.memberInfo.position as MemberPositionKey
                 ] ?? row.memberInfo.position}
               </td>
-              <td className='text-primary truncate px-3 py-4 text-center'>
+              <td className='text-primary px-3 py-4 text-center'>
                 {row.statistic.present}
               </td>
-              <td className='text-disabled truncate px-3 py-4 text-center'>
+              <td className='text-disabled px-3 py-4 text-center'>
                 {row.statistic.late}
               </td>
-              <td className='truncate px-3 py-4 text-center text-neutral-500'>
+              <td className='px-3 py-4 text-center text-neutral-500'>
                 {row.statistic.absent}
               </td>
-              <td className='text-alert truncate px-3 py-4 text-center'>
+              <td className='text-alert px-3 py-4 text-center'>
                 {row.statistic.unauthorizedAbsent}
               </td>
             </tr>

--- a/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_components/table/AdminAttendanceEntireTable.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_components/table/AdminAttendanceEntireTable.tsx
@@ -20,7 +20,7 @@ export const AdminAttendanceEntireTable = ({
             <th
               key={col.key}
               className='text-body-m-sb lg:text-body-l-sb overflow-hidden px-3 py-4 text-neutral-600'>
-              <div className='flex items-center justify-center gap-2.5'>
+              <div className='flex min-w-min items-center justify-center gap-2.5 whitespace-nowrap'>
                 <span className='hidden lg:block'>
                   {col.icon && <col.icon />}
                 </span>

--- a/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_components/table/AdminAttendanceEntireTable.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_components/table/AdminAttendanceEntireTable.tsx
@@ -19,9 +19,11 @@ export const AdminAttendanceEntireTable = ({
           {ATTENDANCE_FULL_TABLE_HEADER.map((col) => (
             <th
               key={col.key}
-              className='text-body-l-sb px-3 py-4 text-neutral-600'>
+              className='text-body-m-sb lg:text-body-l-sb overflow-hidden px-3 py-4 text-neutral-600'>
               <div className='flex items-center justify-center gap-2.5'>
-                {col.icon && <col.icon />}
+                <span className='hidden lg:block'>
+                  {col.icon && <col.icon />}
+                </span>
                 {col.label}
               </div>
             </th>
@@ -39,7 +41,7 @@ export const AdminAttendanceEntireTable = ({
           items.map((row) => (
             <tr
               key={row.memberInfo.memberId}
-              className='text-body-l-sb text-neutral-600'>
+              className='text-body-m lg:text-body-l-sb text-neutral-600'>
               <td className='truncate px-3 py-4 text-center'>
                 {row.memberInfo.name}
               </td>

--- a/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_components/table/AdminAttendanceSpecificTable.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_components/table/AdminAttendanceSpecificTable.tsx
@@ -30,10 +30,8 @@ export const AdminAttendanceSpecificTable = ({
           {ATTENDANCE_SPECIFIC_TABLE_HEADER.map((col) => (
             <th
               key={col.key}
-              className='text-body-m-sb lg:text-body-l-sb px-3 py-4 text-neutral-600'>
-              <div className='flex items-center justify-center gap-2.5'>
-                {col.label}
-              </div>
+              className='text-body-m-sb lg:text-body-l-sb w-max overflow-hidden px-3 py-4 whitespace-nowrap text-neutral-600'>
+              <div>{col.label}</div>
             </th>
           ))}
         </tr>

--- a/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_components/table/AdminAttendanceSpecificTable.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_components/table/AdminAttendanceSpecificTable.tsx
@@ -30,7 +30,7 @@ export const AdminAttendanceSpecificTable = ({
           {ATTENDANCE_SPECIFIC_TABLE_HEADER.map((col) => (
             <th
               key={col.key}
-              className='text-body-l-sb px-3 py-4 text-neutral-600'>
+              className='text-body-m-sb lg:text-body-l-sb px-3 py-4 text-neutral-600'>
               <div className='flex items-center justify-center gap-2.5'>
                 {col.label}
               </div>
@@ -49,7 +49,7 @@ export const AdminAttendanceSpecificTable = ({
           items.map((row) => (
             <tr
               key={row.memberInfo.memberId}
-              className='text-body-l-sb text-center text-neutral-600'>
+              className='text-body-m lg:text-body-l-sb text-center text-neutral-600'>
               <td className='truncate px-3 py-4'>{row.memberInfo.name}</td>
               <td className='truncate px-3 py-4'>
                 {row.memberInfo.generationId}기

--- a/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_components/table/AdminAttendanceSpecificTable.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_components/table/AdminAttendanceSpecificTable.tsx
@@ -48,10 +48,8 @@ export const AdminAttendanceSpecificTable = ({
             <tr
               key={row.memberInfo.memberId}
               className='text-body-m lg:text-body-l-sb text-center text-neutral-600'>
-              <td className='truncate px-3 py-4'>{row.memberInfo.name}</td>
-              <td className='truncate px-3 py-4'>
-                {row.memberInfo.generationId}기
-              </td>
+              <td className='px-3 py-4'>{row.memberInfo.name}</td>
+              <td className='px-3 py-4'>{row.memberInfo.generationId}기</td>
               <td className='px-3 py-4'>
                 <div className='flex items-center justify-center'>
                   <StatusDropdown

--- a/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_containers/TabContainer.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_containers/TabContainer.tsx
@@ -98,8 +98,8 @@ export const TabContainer = () => {
   };
 
   return (
-    <div className='flex items-end'>
-      <div className='flex flex-col gap-2.5'>
+    <div className='flex flex-col gap-5 lg:flex-row lg:items-end lg:gap-0'>
+      <div className='flex w-full flex-col gap-2.5 overflow-x-scroll'>
         <div role='tablist' className='flex gap-7.5' aria-label='파트 선택'>
           {ATTENDANCE_PART_TAB.map(({label, value}, index) => {
             const isActive = activePart === value;
@@ -132,6 +132,7 @@ export const TabContainer = () => {
           </div>
         )}
       </div>
+
       <SearchBar
         keyword={keyword}
         onKeywordChange={setKeyword}

--- a/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_containers/TabContainer.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_containers/TabContainer.tsx
@@ -99,38 +99,43 @@ export const TabContainer = () => {
 
   return (
     <div className='flex flex-col gap-5 lg:flex-row lg:items-end lg:gap-0'>
-      <div className='flex w-full flex-col gap-2.5 overflow-x-scroll'>
-        <div role='tablist' className='flex gap-7.5' aria-label='파트 선택'>
-          {ATTENDANCE_PART_TAB.map(({label, value}, index) => {
-            const isActive = activePart === value;
-            return (
-              <PartTab
-                key={value}
-                partName={label}
-                isActive={isActive}
-                tabIndex={isActive ? 0 : -1}
-                onClick={() => handleTabClick(value)}
-                onKeyDown={(e) => handleKeyDown(e, index)}
-              />
-            );
-          })}
-        </div>
-        {selectedSessionType === 'SPECIFIC' && (
-          <div className='flex gap-2.5' aria-label='출석 상태 선택'>
-            {ATTENDANCE_STATUS_OPTION.map((item) => {
-              const isActive = isAllSelected || activeStatusList.includes(item);
+      <div className='flex w-full flex-col gap-2.5'>
+        <div className='overflow-x-scroll'>
+          <div role='tablist' className='flex gap-7.5' aria-label='파트 선택'>
+            {ATTENDANCE_PART_TAB.map(({label, value}, index) => {
+              const isActive = activePart === value;
               return (
-                <StatusChip
-                  key={item}
-                  value={item}
-                  config={ATTENDANCE_STATUS_CONFIG}
+                <PartTab
+                  key={value}
+                  partName={label}
                   isActive={isActive}
-                  onClick={() => handleChipClick(item)}
+                  tabIndex={isActive ? 0 : -1}
+                  onClick={() => handleTabClick(value)}
+                  onKeyDown={(e) => handleKeyDown(e, index)}
                 />
               );
             })}
           </div>
-        )}
+        </div>
+        <div className='overflow-x-scroll'>
+          {selectedSessionType === 'SPECIFIC' && (
+            <div className='flex gap-2.5' aria-label='출석 상태 선택'>
+              {ATTENDANCE_STATUS_OPTION.map((item) => {
+                const isActive =
+                  isAllSelected || activeStatusList.includes(item);
+                return (
+                  <StatusChip
+                    key={item}
+                    value={item}
+                    config={ATTENDANCE_STATUS_CONFIG}
+                    isActive={isActive}
+                    onClick={() => handleChipClick(item)}
+                  />
+                );
+              })}
+            </div>
+          )}
+        </div>
       </div>
 
       <SearchBar

--- a/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_containers/TabContainer.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_containers/TabContainer.tsx
@@ -100,7 +100,7 @@ export const TabContainer = () => {
   return (
     <div className='flex flex-col gap-5 lg:flex-row lg:items-end lg:gap-0'>
       <div className='flex w-full flex-col gap-2.5'>
-        <div className='overflow-x-scroll'>
+        <div className='overflow-x-scroll [&::-webkit-scrollbar]:hidden'>
           <div role='tablist' className='flex gap-7.5' aria-label='파트 선택'>
             {ATTENDANCE_PART_TAB.map(({label, value}, index) => {
               const isActive = activePart === value;
@@ -117,7 +117,7 @@ export const TabContainer = () => {
             })}
           </div>
         </div>
-        <div className='overflow-x-scroll'>
+        <div className='overflow-x-scroll [&::-webkit-scrollbar]:hidden'>
           {selectedSessionType === 'SPECIFIC' && (
             <div className='flex gap-2.5' aria-label='출석 상태 선택'>
               {ATTENDANCE_STATUS_OPTION.map((item) => {

--- a/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_containers/TableContainer.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_containers/TableContainer.tsx
@@ -87,18 +87,28 @@ export const TableContainer = () => {
       {selectedSessionType === 'FULL' ? (
         <AdminAttendanceEntireTable items={fullAttendanceList} />
       ) : (
-        <div className='flex gap-5'>
-          <AdminAttendanceSpecificTable
-            items={specificAttendanceList.slice(0, half)}
-            onChangeAttendanceStatus={handleChangeAttendanceStatus}
-            isUpdating={isUpdatingAttendanceStatus}
-          />
-          <AdminAttendanceSpecificTable
-            items={specificAttendanceList.slice(half)}
-            onChangeAttendanceStatus={handleChangeAttendanceStatus}
-            isUpdating={isUpdatingAttendanceStatus}
-          />
-        </div>
+        <>
+          <div className='hidden gap-5 lg:flex'>
+            <AdminAttendanceSpecificTable
+              items={specificAttendanceList.slice(0, half)}
+              onChangeAttendanceStatus={handleChangeAttendanceStatus}
+              isUpdating={isUpdatingAttendanceStatus}
+            />
+            <AdminAttendanceSpecificTable
+              items={specificAttendanceList.slice(half)}
+              onChangeAttendanceStatus={handleChangeAttendanceStatus}
+              isUpdating={isUpdatingAttendanceStatus}
+            />
+          </div>
+
+          <div className='lg:hidden'>
+            <AdminAttendanceSpecificTable
+              items={specificAttendanceList}
+              onChangeAttendanceStatus={handleChangeAttendanceStatus}
+              isUpdating={isUpdatingAttendanceStatus}
+            />
+          </div>
+        </>
       )}
     </>
   );

--- a/apps/homepage/src/app/(with-header)/mypage/admin/attendance/page.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/attendance/page.tsx
@@ -7,9 +7,7 @@ export default function AdminAttendancePage() {
   return (
     <section className='px-6 lg:px-11.25'>
       <div className='flex w-full flex-col gap-3 overflow-hidden py-10 pb-7.5 lg:gap-4.5 lg:py-13.5 lg:pb-0'>
-        <h1 className='text-h3 lg:text-h2 hidden text-neutral-800 lg:block'>
-          출석 관리
-        </h1>
+        <h1 className='text-h2 hidden text-neutral-800 lg:block'>출석 관리</h1>
         <DropdownContainer />
         <SuspenseWrapper>
           <TabContainer />

--- a/apps/homepage/src/app/(with-header)/mypage/admin/attendance/page.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/attendance/page.tsx
@@ -5,9 +5,11 @@ import {TabContainer} from '@/app/(with-header)/mypage/admin/attendance/_contain
 
 export default function AdminAttendancePage() {
   return (
-    <section className='px-11.25'>
-      <div className='flex min-w-275 flex-col gap-4.5 py-13.5'>
-        <h1 className='text-h2 text-neutral-800'>출석 관리</h1>
+    <section className='px-6 lg:px-11.25'>
+      <div className='flex w-full flex-col gap-3 overflow-hidden py-10 pb-7.5 lg:gap-4.5 lg:py-13.5 lg:pb-0'>
+        <h1 className='text-h3 lg:text-h2 hidden text-neutral-800 lg:block'>
+          출석 관리
+        </h1>
         <DropdownContainer />
         <SuspenseWrapper>
           <TabContainer />


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->

#338 

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->

관리자페이지의 출석관리 페이지가 모바일에 대응되도록 구현했습니다.
테이블 상단의 '기획', '디자인', ... 과 같은 파트 선택 탭과
'출석', '지각', ... 과 같은 출석 상태 선택 탭이
화면을 넘어갈 경우 가로 스크롤이 되도록 했습니다.

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->


https://github.com/user-attachments/assets/f48e24dc-6025-4053-a101-11af9869908d



<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 모바일 테스트
