### PR TITLE
[DevOps]: PR Reviewers & Assignees 자동 할당 워크플로우 구축

### DIFF
--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -6,13 +6,18 @@ on:
 
 jobs:
   auto-assign:
-    name: PR Assignees 지정
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-      contents: read
+    
     steps:
-      - uses: hkusu/review-assign-action@v1
-        with:
-          assignees: ${{ github.actor }}
-          reviewers: "kimminna,DandelionQZ,JiiminHa,choyeon2e"
+      - name: PR Assignees 지정
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr edit $PR_URL --add-assignee "${{ github.actor }}"
+          
+          REVIEWERS="kimminna,DandelionQZ,JiiminHa,choyeon2e"
+
+          gh pr edit $PR_URL --add-reviewer "$REVIEWERS"

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -12,8 +12,4 @@ jobs:
       - uses: hkusu/review-assign-action@v1
         with:
           assignees: ${{ github.actor }}
-          reviewers: |
-            kimminna
-            DandelionQZ
-            JiiminHa
-            choyeon2e
+          reviewers: kimminna, DandelionQZ, JiiminHa, choyeon2e

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           assignees: ${{ github.actor }}
           reviewers: |
-            kimminna 
-            DandelionQZ 
-            JiiminHa 
-            choyeon2e 
+            kimminna
+            DandelionQZ
+            JiiminHa
+            choyeon2e

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -1,0 +1,19 @@
+name: PR Assignees 지정
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  auto-assign:
+    name: PR Assignees 지정
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hkusu/review-assign-action@v1
+        with:
+          assignees: ${{ github.actor }}
+          reviewers: |
+            kimminna
+            DandelionQZ
+            JiiminHa
+            choyeon2e

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -12,4 +12,4 @@ jobs:
       - uses: hkusu/review-assign-action@v1
         with:
           assignees: ${{ github.actor }}
-          reviewers: kimminna, DandelionQZ, JiiminHa, choyeon2e
+          reviewers: "kimminna,DandelionQZ,JiiminHa,choyeon2e"

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -8,6 +8,9 @@ jobs:
   auto-assign:
     name: PR Assignees 지정
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
     steps:
       - uses: hkusu/review-assign-action@v1
         with:

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -2,7 +2,7 @@ name: PR Assignees 지정
 
 on:
   pull_request:
-    types: [opened, ready_for_review, synchronize]
+    types: [opened, ready_for_review]
 
 jobs:
   auto-assign:
@@ -17,7 +17,7 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
           gh pr edit $PR_URL --add-assignee "${{ github.actor }}"
-          
+
           REVIEWERS="kimminna,DandelionQZ,JiiminHa,choyeon2e"
 
           gh pr edit $PR_URL --add-reviewer "$REVIEWERS"

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -2,7 +2,7 @@ name: PR Assignees 지정
 
 on:
   pull_request:
-    types: [opened, ready_for_review]
+    types: [opened, ready_for_review, synchronize]
 
 jobs:
   auto-assign:

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           assignees: ${{ github.actor }}
           reviewers: |
-            kimminna
-            DandelionQZ
-            JiiminHa
-            choyeon2e
+            kimminna 
+            DandelionQZ 
+            JiiminHa 
+            choyeon2e 


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->

close #347 

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->

직접 PR을 생성할 때마다 리뷰어와 할당자를 수동으로 지정해야 하는 번거로움을 해결하기 위해 GitHub Actions를 이용한 리뷰어 자동 할당 워크플로우를 구축했습니다.

<img width="559" height="49" alt="image" src="https://github.com/user-attachments/assets/9b5e5b4c-2618-4dc4-8a76-844dd6e26a90" />
<img width="599" height="85" alt="image" src="https://github.com/user-attachments/assets/a21a7f92-ac0c-432f-9b8a-b4877b0ec7ea" />

이런 식으로 직접 할당자 / 리뷰어 지정 필요 없이 자동적으로 할당되게 설정해 뒀어요. (원래는 오픈소스 워크플로우를 사용하려고 했는데, 코드래빗이 리뷰어로 이미 할당되어 있는 경우 워크플로우를 무시하는 문제가 있어서 직접 gh 명령어로 할당하게 변경해 뒀습니다.)

<br><br>

<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 정의된 리뷰어 목록(kimminna, DandelionQZ, JiiminHa, choyeon2e) 확인 
