### PR TITLE
[UI]: 리크루트 모집활성화 및 합격자관리 스피너 위치 조정

### DIFF
--- a/apps/recruit/src/app/admin/(with-sidebar)/recruitment/_components/RecruitmentContainer.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/recruitment/_components/RecruitmentContainer.tsx
@@ -6,14 +6,16 @@ import {ActiveRecruitment} from './active-recruitment/ActiveRecruitment';
 import {ManageMail} from './manage-mail/ManageMail';
 import {useRecruitmentStatusQuery} from '@/hooks/queries/useRecruitmentStatus.query';
 import {Spinner} from '@repo/ui/components/spinner/Spinner';
+import {useAdminGenerationsQuery} from '@/hooks/queries/useAdminGeneration.query';
 
 export const RecruitmentContainer = () => {
-  const {isLoading} = useRecruitmentStatusQuery();
+  const {isLoading: isStatusLoading} = useRecruitmentStatusQuery();
+  const {isLoading: isGenerationsLoading} = useAdminGenerationsQuery();
   const {generation} = useRecruitmentStore();
 
-  if (isLoading)
+  if (isStatusLoading || isGenerationsLoading)
     return (
-      <div className='flex w-full justify-center'>
+      <div className='flex h-full w-full items-center justify-center'>
         <Spinner size='lg' />
       </div>
     );

--- a/apps/recruit/src/app/admin/(with-sidebar)/recruitment/_components/add-generation/AddGenerationContainer.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/recruitment/_components/add-generation/AddGenerationContainer.tsx
@@ -8,15 +8,13 @@ import {PlusButton} from '@/app/admin/(with-sidebar)/recruitment/_components/add
 import {AddGenerationModal} from './AddGenerationModal';
 import clsx from 'clsx';
 import {useAdminGenerationsQuery} from '@/hooks/queries/useAdminGeneration.query';
-import {Spinner} from '@repo/ui/components/spinner/Spinner';
 
 export const AddGenerationContainer = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const {data: statusData, isLoading: isStatusLoading} =
     useRecruitmentStatusQuery();
-  const {data: generationsData, isLoading: isGenerationsLoading} =
-    useAdminGenerationsQuery();
+  const {data: generationsData} = useAdminGenerationsQuery();
 
   const {
     generations,
@@ -58,13 +56,6 @@ export const AddGenerationContainer = () => {
 
   const isRecruiting = statusData?.isActive ?? false;
   const currentGeneration = statusData?.generationId;
-
-  if (isStatusLoading || isGenerationsLoading)
-    return (
-      <div className='flex w-full justify-center'>
-        <Spinner size='lg' />
-      </div>
-    );
 
   return (
     <div className='flex w-full flex-col items-start gap-2.5 rounded-[10px] bg-neutral-100 px-5 py-3 lg:px-8 lg:py-3'>

--- a/apps/recruit/src/app/admin/(with-sidebar)/recruitment/_components/manage-mail/ManageMail.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/recruitment/_components/manage-mail/ManageMail.tsx
@@ -7,7 +7,6 @@ import {MailHeader} from './MailHeader';
 import {MailField} from './MailField';
 import {MailSendFooter} from './MailSendFooter';
 import {MailConfirmModal} from '@/components/modal/MailConfirmModal';
-import {Spinner} from '@repo/ui/components/spinner/Spinner';
 import {useGenerationStore} from '@/store/useGenerationStore';
 
 interface ManageMailProps {
@@ -29,7 +28,6 @@ export const ManageMail = ({
   );
 
   const {
-    isLoading,
     isEditing,
     content,
     setContent,
@@ -63,13 +61,6 @@ export const ManageMail = ({
   const finalCanEdit = canAccess && !isSent;
   const finalCanSend =
     canAccess && hasPermission && !isSent && waitingCount > 0;
-
-  if (isLoading)
-    return (
-      <div className='flex w-full justify-center'>
-        <Spinner size='lg' />
-      </div>
-    );
 
   return (
     <div className='flex w-full flex-col gap-2.5 lg:gap-3.5'>

--- a/apps/recruit/src/app/admin/(with-sidebar)/results/_components/ResultsContainer.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/results/_components/ResultsContainer.tsx
@@ -7,6 +7,7 @@ import {useGenerationStore} from '@/store/useGenerationStore';
 import {useRecruitmentStatusQuery} from '@/hooks/queries/useRecruitmentStatus.query';
 import {Spinner} from '@repo/ui/components/spinner/Spinner';
 import {useAdminGenerationsQuery} from '@/hooks/queries/useAdminGeneration.query';
+import {useAdminPassStatusQuery} from '@/hooks/queries/useAdminResult.query';
 
 export const ResultsContainer = () => {
   const {isLoading: isStatusLoading} = useRecruitmentStatusQuery();
@@ -15,6 +16,12 @@ export const ResultsContainer = () => {
 
   const {setGenerations} = useGenerationStore();
   const [selectedGen, setSelectedGen] = useState<string | null>(null);
+  const generations = generationsData?.data || [];
+  const currentGeneration =
+    selectedGen ||
+    (generations.length > 0 ? String(generations[0].generationId) : '');
+  const {isLoading: isPassStatusLoading} =
+    useAdminPassStatusQuery(currentGeneration);
 
   useEffect(() => {
     if (generationsData?.data) {
@@ -22,18 +29,13 @@ export const ResultsContainer = () => {
     }
   }, [generationsData, setGenerations]);
 
-  if (isStatusLoading || isGenerationsLoading) {
+  if (isStatusLoading || isGenerationsLoading || isPassStatusLoading) {
     return (
-      <div className='flex h-100 w-full items-center justify-center'>
+      <div className='flex h-[calc(100vh)] w-full items-center justify-center'>
         <Spinner size='lg' />
       </div>
     );
   }
-
-  const generations = generationsData?.data || [];
-  const currentGeneration =
-    selectedGen ||
-    (generations.length > 0 ? String(generations[0].generationId) : '');
 
   if (!currentGeneration) {
     return (

--- a/apps/recruit/src/app/admin/(with-sidebar)/results/_components/result-manage/ManageResult.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/results/_components/result-manage/ManageResult.tsx
@@ -2,7 +2,6 @@
 
 import {useAdminPassStatusQuery} from '@/hooks/queries/useAdminResult.query';
 import {GenerationDropdown} from '@/components/dropdown/GenerationDropdown';
-import {Spinner} from '@repo/ui/components/spinner/Spinner';
 import {useGenerationStore} from '@/store/useGenerationStore';
 import {ResultTable} from '@/app/admin/(with-sidebar)/results/_components/result-manage/ResultTable';
 
@@ -15,16 +14,9 @@ export const ManageResult = ({
   generation,
   onGenerationChange,
 }: ManageResultProps) => {
-  const {data, isLoading} = useAdminPassStatusQuery(generation);
+  const {data} = useAdminPassStatusQuery(generation);
   const {generations} = useGenerationStore();
   const generationList = generations.map((g) => String(g.generationId));
-
-  if (isLoading)
-    return (
-      <div className='flex justify-center py-10'>
-        <Spinner />
-      </div>
-    );
 
   return (
     <div className='flex w-full flex-col gap-2.5 lg:gap-3.5'>


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->

close #351

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->

## 리크루트 모집활성화, 합격자관리 스피너 수정

원래는 해당 페이지들 스피너가 중복으로 설정되어있는 문제가 있어서 중복된 스피너를 제거하고 상위 컨테이너에서 페이지의 모든 로딩을 처리해 스피너를 띄우도록 했습니다. 추가로 스피너의 위치도 화면 높이 중앙으로 배치했습니다.

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->



<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 모집활성화 스피너 확인
- [ ] 합격자관리 스피너 확인