### PR TITLE
[UI]: 홈페이지 프로젝트, 나의 활동 페이지 스피너 위치 조정

### DIFF
--- a/apps/homepage/src/app/(with-header)/(with-footer)/project/[projectId]/_container/ProjectDetailContainer.tsx
+++ b/apps/homepage/src/app/(with-header)/(with-footer)/project/[projectId]/_container/ProjectDetailContainer.tsx
@@ -43,7 +43,7 @@ export const ProjectDetailContainer = () => {
 
   if (isLoading)
     return (
-      <div className='flex min-h-100 items-center justify-center'>
+      <div className='flex min-h-screen items-center justify-center'>
         <Spinner />
         <span className='sr-only'>프로젝트 상세 정보를 불러오는 중입니다.</span>
       </div>

--- a/apps/homepage/src/app/(with-header)/(with-footer)/project/_components/ProjectContainer.tsx
+++ b/apps/homepage/src/app/(with-header)/(with-footer)/project/_components/ProjectContainer.tsx
@@ -10,6 +10,8 @@ import {ACTIVITY_MAP} from '@/constants/project/project-activity';
 import {useGenerationQuery} from '@/hooks/queries/useGeneration.query';
 import {Spinner} from '@repo/ui/components/spinner/Spinner';
 import {useAuthStore} from '@/store/useAuthStore';
+import {useProjectListQuery} from '@/hooks/queries/useProject.query';
+import {ProjectType} from '@/schemas/project/project-type';
 
 export const ProjectContainer = () => {
   const router = useRouter();
@@ -21,7 +23,13 @@ export const ProjectContainer = () => {
   const actParam = searchParams.get('act'); // null이면 전체
   const isAdmin = user?.isAdmin === true;
 
-  const {data: generations = [], isLoading} = useGenerationQuery();
+  const {data: generations = [], isLoading: isGenLoading} =
+    useGenerationQuery();
+
+  const {isLoading: isProjectLoading} = useProjectListQuery({
+    generationId: genParam ? Number(genParam) : undefined,
+    projectType: actParam ? (actParam.toUpperCase() as ProjectType) : undefined,
+  });
 
   const sortedGenerations = useMemo(() => {
     return [...generations].sort((a, b) => b.generationId - a.generationId);
@@ -71,12 +79,9 @@ export const ProjectContainer = () => {
     [updateQuery]
   );
 
-  if (isLoading) {
+  if (isGenLoading || isProjectLoading) {
     return (
-      <div
-        className='flex min-h-100 items-center justify-center'
-        aria-live='polite'
-        aria-busy='true'>
+      <div className='flex min-h-screen w-full items-center justify-center'>
         <Spinner />
       </div>
     );

--- a/apps/homepage/src/app/(with-header)/(with-footer)/project/_components/ProjectSection.tsx
+++ b/apps/homepage/src/app/(with-header)/(with-footer)/project/_components/ProjectSection.tsx
@@ -6,7 +6,6 @@ import {ProjectCard} from './ProjectCard';
 import {Pagination} from '@repo/ui/components/pagination/Pagination';
 import {useProjectListQuery} from '@/hooks/queries/useProject.query';
 import {ProjectType} from '@/schemas/project/project-type';
-import {Spinner} from '@repo/ui/components/spinner/Spinner';
 
 interface ProjectSectionProps {
   generation?: string;
@@ -36,7 +35,7 @@ export const ProjectSection = ({generation, activity}: ProjectSectionProps) => {
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  const {data: projects = [], isLoading} = useProjectListQuery({
+  const {data: projects = []} = useProjectListQuery({
     generationId: generation ? Number(generation) : undefined,
     projectType: activity ? (activity.toUpperCase() as ProjectType) : undefined,
   });
@@ -61,17 +60,6 @@ export const ProjectSection = ({generation, activity}: ProjectSectionProps) => {
       handlePageChange(totalPages);
     }
   }, [totalPages, currentPage, handlePageChange]);
-
-  if (isLoading) {
-    return (
-      <div
-        className='flex min-h-100 items-center justify-center'
-        aria-live='polite'
-        aria-busy='true'>
-        <Spinner />
-      </div>
-    );
-  }
 
   return (
     <div className='flex w-full flex-col items-center gap-10'>

--- a/apps/homepage/src/app/(with-header)/(with-footer)/project/add-project/_containers/AddProjectFormContainer.tsx
+++ b/apps/homepage/src/app/(with-header)/(with-footer)/project/add-project/_containers/AddProjectFormContainer.tsx
@@ -59,7 +59,7 @@ export const AddProjectFormContainer = () => {
   if (isGenLoading || (editId && isDetailLoading)) {
     return (
       <div
-        className='flex min-h-100 items-center justify-center'
+        className='flex min-h-screen items-center justify-center'
         role='status'
         aria-live='polite'
         aria-busy='true'>

--- a/apps/homepage/src/app/(with-header)/mypage/activity/_containers/AttendanceCheckContainer.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/activity/_containers/AttendanceCheckContainer.tsx
@@ -74,7 +74,7 @@ export const AttendanceCheckContainer = ({activeTab}: {activeTab: TabType}) => {
           isBorder
         />
       </div>
-      <div className='flex flex-col justify-center rounded-[10px] bg-neutral-50 px-2.5 py-2.5 text-center lg:min-h-75 lg:px-15.75 lg:py-7'>
+      <div className='flex min-h-55.75 flex-col justify-center rounded-[10px] bg-neutral-50 px-2.5 py-2.5 text-center lg:min-h-75 lg:px-15.75 lg:py-7'>
         {isDataLoading ? (
           <div className='flex h-full items-center justify-center'>
             <Spinner />

--- a/apps/homepage/src/app/(with-header)/mypage/activity/_containers/AttendanceCheckContainer.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/activity/_containers/AttendanceCheckContainer.tsx
@@ -76,7 +76,7 @@ export const AttendanceCheckContainer = ({activeTab}: {activeTab: TabType}) => {
       </div>
       <div className='flex flex-col justify-center rounded-[10px] bg-neutral-50 px-2.5 py-2.5 text-center lg:min-h-75 lg:px-15.75 lg:py-7'>
         {isDataLoading ? (
-          <div className='flex items-center justify-center py-20'>
+          <div className='flex h-full items-center justify-center'>
             <Spinner />
           </div>
         ) : (

--- a/apps/homepage/src/app/(with-header)/mypage/activity/_containers/AttendanceContainer.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/activity/_containers/AttendanceContainer.tsx
@@ -8,7 +8,9 @@ import {AttendanceStatusContainer} from '@/app/(with-header)/mypage/activity/_co
 import {TabType} from '@/schemas/mypage-mem/activity/mypage-mem-type';
 import {
   useAttendanceDashboardQuery,
+  useAttendanceRecordsQuery,
   usePenaltyDashboardQuery,
+  usePenaltyRecordsQuery,
 } from '@/hooks/queries/useActivity.queries';
 import {ErrorResponse} from '@/schemas/common/common-schema';
 import {NotActiveMemberView} from '@/app/(with-header)/mypage/activity/_components/NotActiveMemberView';
@@ -24,7 +26,25 @@ export const AttendanceContainer = () => {
   const {error: penaltyError, isLoading: isPenaltyLoading} =
     usePenaltyDashboardQuery({enabled: !isAttendance});
 
-  const isLoading = isAttendance ? isAttendLoading : isPenaltyLoading;
+  const currentMonth = new Date().getMonth() + 1;
+
+  const {isLoading: isAttendRecordLoading} = useAttendanceRecordsQuery(
+    currentMonth,
+    {
+      enabled: isAttendance,
+    }
+  );
+  const {isLoading: isPenaltyRecordLoading} = usePenaltyRecordsQuery(
+    currentMonth,
+    {
+      enabled: !isAttendance,
+    }
+  );
+
+  const isLoading = isAttendance
+    ? isAttendLoading || isAttendRecordLoading
+    : isPenaltyLoading || isPenaltyRecordLoading;
+
   const currentError = (
     isAttendance ? attendError : penaltyError
   ) as AxiosError<ErrorResponse> | null;


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->

close #354

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->

## 홈페이지 프로젝트, 마이페이지 MEM 페이지 스피너 위치 조정

이전 PR처럼 홈페이지 프로젝트, 나의 활동 페이지의 중복된 스피너를 제거하고, 상위 컨테이너에서 페이지의 모든 로딩을 처리해 스피너를 띄우도록 했습니다. (다른 마이페이지 MEM 페이지들은 기존에 제대로 구현되어있어서 수정하지 않았습니다!) 

스피너의 위치도 화면 높이 중앙으로 배치했습니다.

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->

<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 프로젝트 전체 조회 페이지 스피너 위치 확인
- [ ] 프로젝트 상세 조회 페이지 스피너 위치 확인
- [ ] 프로젝트 추가/수정 페이지 스피너 위치 확인
- [ ] 나의활동 페이지 스피너 위치 확인