### PR TITLE
[FIX] 5차 QA 수정사항 반영

### DIFF
--- a/apps/homepage/global.d.ts
+++ b/apps/homepage/global.d.ts
@@ -1,0 +1,2 @@
+declare module '*.css';
+declare module '*.scss';

--- a/apps/homepage/src/app/(with-header)/(with-footer)/project/add-project/_components/PeriodField.tsx
+++ b/apps/homepage/src/app/(with-header)/(with-footer)/project/add-project/_components/PeriodField.tsx
@@ -55,6 +55,7 @@ export const PeriodField = ({
           formatWeekDay={(nameOfDay) => nameOfDay.toLowerCase().slice(0, 3)}
           renderCustomHeader={(props) => <CustomHeader {...props} />}
           disabledKeyboardNavigation
+          portalId='datepicker-portal'
         />
       </div>
       <div
@@ -77,6 +78,7 @@ export const PeriodField = ({
           formatWeekDay={(nameOfDay) => nameOfDay.toLowerCase().slice(0, 3)}
           renderCustomHeader={(props) => <CustomHeader {...props} />}
           disabledKeyboardNavigation
+          portalId='datepicker-portal'
         />
       </div>
     </div>

--- a/apps/homepage/src/app/(with-header)/mypage/attendance/_components/SessionCard.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/attendance/_components/SessionCard.tsx
@@ -155,7 +155,7 @@ export const SessionCard = ({
                   <span className='lg:text-h5 text-body-l-b text-neutral-400'>
                     세션 설명
                   </span>
-                  <p className='lg:text-h5 text-body-m wrap-break-words whitespace-normal text-neutral-600'>
+                  <p className='lg:text-h5 text-body-m wrap-break-word whitespace-normal text-neutral-600'>
                     {session.description || '설명이 없습니다.'}
                   </p>
                 </div>
@@ -163,7 +163,7 @@ export const SessionCard = ({
                   <span className='lg:text-h5 text-body-l-b text-neutral-400'>
                     세션 장소
                   </span>
-                  <p className='lg:text-h5 text-body-m wrap-break-words whitespace-normal text-neutral-600'>
+                  <p className='lg:text-h5 text-body-m wrap-break-word whitespace-normal text-neutral-600'>
                     {session.sessionType === 'ONLINE' && !session.placeName ? (
                       '온라인 세션'
                     ) : (

--- a/apps/homepage/src/app/(with-header)/mypage/attendance/_components/SessionCard.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/attendance/_components/SessionCard.tsx
@@ -150,20 +150,20 @@ export const SessionCard = ({
                 </h4>
               </div>
               <div className='h-px w-full shrink-0 bg-neutral-200' />
-              <div className='flex flex-row gap-2.75 lg:gap-10'>
-                <div className='flex flex-1 flex-col gap-1.75 lg:gap-1'>
+              <div className='flex w-full items-start gap-2.75 self-stretch lg:gap-10'>
+                <div className='flex min-w-0 flex-1 flex-col items-start gap-1.75'>
                   <span className='lg:text-h5 text-body-l-b text-neutral-400'>
                     세션 설명
                   </span>
-                  <p className='lg:text-h5 text-body-m text-neutral-600'>
+                  <p className='lg:text-h5 text-body-m wrap-break-words whitespace-normal text-neutral-600'>
                     {session.description || '설명이 없습니다.'}
                   </p>
                 </div>
-                <div className='flex flex-col gap-1 lg:w-94.25 lg:shrink-0'>
+                <div className='flex min-w-0 flex-1 flex-col items-start gap-1.75'>
                   <span className='lg:text-h5 text-body-l-b text-neutral-400'>
                     세션 장소
                   </span>
-                  <p className='lg:text-h5 text-body-m text-neutral-600'>
+                  <p className='lg:text-h5 text-body-m wrap-break-words whitespace-normal text-neutral-600'>
                     {session.sessionType === 'ONLINE' && !session.placeName ? (
                       '온라인 세션'
                     ) : (

--- a/apps/homepage/src/app/layout.tsx
+++ b/apps/homepage/src/app/layout.tsx
@@ -104,6 +104,7 @@ export default function RootLayout({
             ) : null}
             <BeUsableRum />
             <main>{children}</main>
+            <div id='datepicker-portal' className='z-datepicker relative' />
           </body>
         </AuthProvider>
       </Providers>

--- a/apps/recruit/global.d.ts
+++ b/apps/recruit/global.d.ts
@@ -1,0 +1,2 @@
+declare module '*.css';
+declare module '*.scss';

--- a/packages/ui/src/components/form/FormLink.tsx
+++ b/packages/ui/src/components/form/FormLink.tsx
@@ -101,14 +101,14 @@ export const FormLink = forwardRef<HTMLInputElement, FormLinkProps>(
               ref={ref}
               type='text'
               placeholder={
-                placeholder ?? 
-                (isMobile 
-                  ? '링크를 입력해주세요' 
+                placeholder ??
+                (isMobile
+                  ? '링크를 입력해주세요'
                   : '쉼표(,)로 여러 링크를 구분할 수 있습니다.')
               }
               value={rawLinks[0] || ''}
               onChange={handleChange}
-              className='flex-1 outline-none'
+              className='min-w-0 flex-1 outline-none'
               {...props}
             />
           </div>


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->

close #357 

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->

## (root) css import 오류 수정
모든 css import문에 빨간줄로 가져오기 오류가 뜨던 문제를 해결했습니다.
homepage, recruit 두 app에 모두 발생하던 문제라서 homepage, recruit 내부 루트에 전역 타입 선언 파일인 `global.d.ts` 파일을 생성하고 그 안에 css, scss를 명시적으로 선언해두었어요! 

<br>

## (root) FormLink 컴포넌트 width 밖으로 텍스트가 넘어가는 문제 수정
5차 QA 프로젝트 페이지 확인 중 발견한 FormLink 컴포넌트의 텍스트가 컴포넌트 자체 width를 넘어가는 문제를 해결했습니다.
min-w-0을 추가해서 부모 컨테이너 내부에서만 텍스트가 표시되도록 수정했습니다.

<br>

## 프로젝트 추가/수정 페이지 datepicker portal 추가
프로젝트 추가/수정 페이지에서 사용되는 PeriodField 컴포넌트 내 datepicker에 datepicker-portal를 추가해서 기존에 HeroMainBanner 컴포넌트 하단으로 datepicker가 잘려보이는 문제를 수정했습니다. 

기존에 z-index를 datepicker용으로 더 높게 설정해두어도 자꾸 `HeroMainBanner` 아래로 잘려보이는 문제가 발생했는데 그 이유를 알아보니 `HeroMainBanner`에 `overflow:hidden` 속성이 설정되어있어서 그렇다고합니다.
- 좀 더 구체적으로는 `overflow: hidden`이 해당 요소의 경계를 벗어나는 모든 자식 요소를 숨기는데, 그 속성 때문에 기존처럼 datepicker가 배너의 하단 경계선에 걸치게 되면 **z-index와 상관없이** 물리적으로 잘려 보이게 된다고하네요

그렇다고 HeroMainBanner의 `overflow: hidden` 속성을 없앨 수 없었기 때문에... 결론적으로 z-index만으로는 해결할 수 없는 문제였기에 최후의 방법으로 portal를 사용하게되었습니다. RootLayout와 PeriodField 내 datepicker에 portalId 설정해두었습니다.

<br>

## 출석하기 SessionCard 속 세션설명, 세션장소 스타일 수정
기기 너비에 따라 세션설명, 세션 장소 스타일이 깨져보여서 이를 수정했습니다. 세션 설명, 세션 장소를 묶어주는 div의 전체적인 구조를 반응형에 따라 50:50으로 조절되도록 수정하고 사이 gap은 디자인에 맞춰 11px로 설정했어요

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->

### css문 import 오류 수정
| 기존  | 해결|
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/d3766d4a-7f7b-46b4-ac79-59854cc1b699" width="100%" /> | <img src="https://github.com/user-attachments/assets/7dd7a956-9786-41df-8f9d-321aa1f24b9b" width="100%" /> |

<br>

### FormLink 컴포넌트 수정
<img width="1624" height="973" alt="스크린샷 2026-04-15 23 59 09" src="https://github.com/user-attachments/assets/bf84ef87-324b-4fdf-b221-414397aebcbe" />

<br>

### datepicker HeroMainBanner 위로 올라오도록 수정
<img width="3248" height="1946" alt="datepicker" src="https://github.com/user-attachments/assets/6244bb02-73c8-4d37-bf66-da1679ca0fe9" />

<br>

### SessionCard 스타일 수정
<img width="3248" height="1946" alt="sessioncard" src="https://github.com/user-attachments/assets/af2b7885-ad53-4de0-9484-64694b569775" />



<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [x] css import 오류 수정 확인
- [x] 프로젝트 추가/수정 페이지의 datepicker가 HeroMainBanner 위로 잘 올라오는지 확인
- [x] 모바일 프로젝트 추가/수정 페이지에서 링크(FormLink)부분 텍스트가 컴포넌트 너비 안넘어가는지 확인
- [x] 모바일 출석하기 페이지 세션카드 세션설명, 세션장소 안깨지는거 확인
