### PR TITLE
[FIX]: 5차 QA 수정사항 반영

### DIFF
--- a/apps/homepage/src/app/(with-header)/(with-footer)/recruit/_components/ActivityCard.tsx
+++ b/apps/homepage/src/app/(with-header)/(with-footer)/recruit/_components/ActivityCard.tsx
@@ -58,14 +58,14 @@ export const ActivityCard = ({item}: ActivityCardProps) => {
       <div className='relative z-20 flex justify-between'>
         <p
           className={clsx(
-            'text-h4 text-neutral-50 transition-colors duration-300',
+            'text-h4 font-bold text-neutral-50 transition-colors duration-300',
             isActive ? 'text-neutral-800' : 'group-hover:text-neutral-800'
           )}>
           {item.name}
         </p>
         <p
           className={clsx(
-            'text-h5 text-neutral-200 transition-colors duration-300',
+            'text-h5 font-semibold text-neutral-200 transition-colors duration-300',
             isActive ? 'text-neutral-600' : 'group-hover:text-neutral-600'
           )}>
           {item.date}

--- a/apps/homepage/src/app/(with-header)/(with-footer)/recruit/_components/ActivityList.tsx
+++ b/apps/homepage/src/app/(with-header)/(with-footer)/recruit/_components/ActivityList.tsx
@@ -7,14 +7,15 @@ interface ActivityListProps {
 
 export const ActivityList = ({activities}: ActivityListProps) => {
   return (
-    <div className='flex flex-col gap-12.5 px-6 py-12.5 lg:px-0 lg:py-0'>
+    <div className='flex flex-col px-6 py-12.5 lg:px-0 lg:py-0'>
       <div className='flex flex-col'>
         <p className='text-h3 lg:text-h2 mb-2.5 text-center text-neutral-800'>
           주요 활동 일정
         </p>
-        <p className='text-h5 mb-1 text-center text-neutral-600'>
-          정기 세션은 <span className='text-primary'>매주 금요일 19시</span>
-          에&nbsp;<span className='text-primary'>오프라인</span>으로 진행됩니다
+        <p className='text-h5 mb-1 text-center font-bold text-neutral-600 lg:font-semibold'>
+          정기 세션은 <span className='text-primary'>매주 금요일 19시</span>에
+          <br />
+          <span className='text-primary'>오프라인</span>으로 진행됩니다
         </p>
         <p className='text-body-l mb-7.5 text-center text-neutral-500'>
           세부 일정은 추후 변경될 수 있습니다.

--- a/apps/homepage/src/app/(with-header)/(with-footer)/recruit/_components/FaqAccordion.tsx
+++ b/apps/homepage/src/app/(with-header)/(with-footer)/recruit/_components/FaqAccordion.tsx
@@ -24,7 +24,7 @@ export const FaqAccordion = ({item}: FaqAccordionProps) => {
       <div className='flex w-full items-center justify-between self-stretch'>
         <p
           className={clsx(
-            'text-h5 text-start transition-colors duration-300',
+            'text-h5 text-start font-semibold transition-colors duration-300',
             isOpen ? 'text-neutral-800' : 'text-neutral-600'
           )}>
           {item.question}

--- a/apps/homepage/src/app/(with-header)/(with-footer)/recruit/_components/FaqSideBar.tsx
+++ b/apps/homepage/src/app/(with-header)/(with-footer)/recruit/_components/FaqSideBar.tsx
@@ -28,7 +28,7 @@ export const FaqSideBar = ({activatedMenu, onActive}: FaqSideBarProps) => {
               onClick={() => onActive(dataKey as faqParametersType)}>
               <p
                 className={clsx(
-                  'text-h5 w-36 cursor-pointer rounded-[5px] px-2 py-1.25 transition-colors duration-300 lg:w-45.25',
+                  'text-h5 w-36 cursor-pointer rounded-[5px] px-2 py-1.25 font-semibold transition-colors duration-300 lg:w-45.25',
                   dataKey === activatedMenu
                     ? 'bg-neutral-800 text-neutral-100'
                     : 'bg-neutral-50 text-neutral-800 lg:bg-transparent'

--- a/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_components/table/AdminAttendanceEntireTable.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_components/table/AdminAttendanceEntireTable.tsx
@@ -13,14 +13,14 @@ export const AdminAttendanceEntireTable = ({
   items,
 }: AdminAttendanceEntireTableProps) => {
   return (
-    <table className='h-fit w-full table-fixed border-collapse'>
+    <table className='h-fit w-full table-auto border-collapse'>
       <thead className='bg-neutral-200'>
         <tr>
           {ATTENDANCE_FULL_TABLE_HEADER.map((col) => (
             <th
               key={col.key}
-              className='text-body-m-sb lg:text-body-l-sb overflow-hidden px-3 py-4 text-neutral-600'>
-              <div className='flex min-w-min items-center justify-center gap-2.5 whitespace-nowrap'>
+              className='text-body-m-sb lg:text-body-l-sb min-w-12.5 overflow-hidden py-2.5 text-neutral-600 lg:py-4'>
+              <div className='flex items-center justify-center gap-2.5 whitespace-nowrap'>
                 <span className='hidden lg:block'>
                   {col.icon && <col.icon />}
                 </span>
@@ -33,7 +33,9 @@ export const AdminAttendanceEntireTable = ({
       <tbody>
         {items.length === 0 ? (
           <tr>
-            <td colSpan={6} className='py-15 text-center text-neutral-400'>
+            <td
+              colSpan={6}
+              className='min-w-max py-15 text-center text-neutral-400'>
               출석 내역이 없습니다.
             </td>
           </tr>
@@ -42,22 +44,24 @@ export const AdminAttendanceEntireTable = ({
             <tr
               key={row.memberInfo.memberId}
               className='text-body-m lg:text-body-l-sb text-neutral-600'>
-              <td className='px-3 py-4 text-center'>{row.memberInfo.name}</td>
-              <td className='truncate px-3 py-4 text-center'>
+              <td className='min-w-max px-3 py-4 text-center whitespace-nowrap'>
+                {row.memberInfo.name}
+              </td>
+              <td className='min-w-max px-3 py-4 text-center whitespace-nowrap'>
                 {MEMBER_POSITION_LABEL[
                   row.memberInfo.position as MemberPositionKey
                 ] ?? row.memberInfo.position}
               </td>
-              <td className='text-primary px-3 py-4 text-center'>
+              <td className='text-primary min-w-max px-3 py-4 text-center whitespace-nowrap'>
                 {row.statistic.present}
               </td>
-              <td className='text-disabled px-3 py-4 text-center'>
+              <td className='text-disabled min-w-max px-3 py-4 text-center whitespace-nowrap'>
                 {row.statistic.late}
               </td>
-              <td className='px-3 py-4 text-center text-neutral-500'>
+              <td className='min-w-max px-3 py-4 text-center whitespace-nowrap text-neutral-500'>
                 {row.statistic.absent}
               </td>
-              <td className='text-alert px-3 py-4 text-center'>
+              <td className='text-alert min-w-max px-3 py-4 text-center whitespace-nowrap'>
                 {row.statistic.unauthorizedAbsent}
               </td>
             </tr>

--- a/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_components/table/AdminAttendanceSpecificTable.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_components/table/AdminAttendanceSpecificTable.tsx
@@ -24,13 +24,13 @@ export const AdminAttendanceSpecificTable = ({
   isUpdating,
 }: AdminAttendanceSpecificTableProps) => {
   return (
-    <table className='h-fit w-full table-fixed border-collapse'>
+    <table className='h-fit w-full table-auto border-collapse'>
       <thead className='bg-neutral-200'>
         <tr>
           {ATTENDANCE_SPECIFIC_TABLE_HEADER.map((col) => (
             <th
               key={col.key}
-              className='text-body-m-sb lg:text-body-l-sb w-max overflow-hidden px-3 py-4 whitespace-nowrap text-neutral-600'>
+              className='text-body-m-sb lg:text-body-l-sb w-max min-w-max overflow-hidden py-2.5 whitespace-nowrap text-neutral-600 lg:py-4'>
               <div>{col.label}</div>
             </th>
           ))}
@@ -48,10 +48,14 @@ export const AdminAttendanceSpecificTable = ({
             <tr
               key={row.memberInfo.memberId}
               className='text-body-m lg:text-body-l-sb text-center text-neutral-600'>
-              <td className='px-3 py-4'>{row.memberInfo.name}</td>
-              <td className='px-3 py-4'>{row.memberInfo.generationId}기</td>
-              <td className='px-3 py-4'>
-                <div className='flex items-center justify-center'>
+              <td className='min-w-max px-3 py-4 whitespace-nowrap'>
+                {row.memberInfo.name}
+              </td>
+              <td className='min-w-max px-3 py-4 whitespace-nowrap'>
+                {row.memberInfo.generationId}기
+              </td>
+              <td className='min-w-max px-3 py-4'>
+                <div className='flex items-center justify-center whitespace-nowrap'>
                   <StatusDropdown
                     value={row.result ?? 'NOT_YET'}
                     options={ATTENDANCE_STATUS_OPTION}

--- a/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_containers/DropdownContainer.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_containers/DropdownContainer.tsx
@@ -84,7 +84,7 @@ export const DropdownContainer = () => {
   }, [selectedSession, sessions, setAttendanceId, setSelectedSessionType]);
 
   return (
-    <div className='flex gap-5'>
+    <div className='flex gap-5 px-6 lg:px-11.25'>
       <Dropdown
         placeholder='기수'
         value={selectedGeneration}

--- a/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_containers/TabContainer.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_containers/TabContainer.tsx
@@ -98,7 +98,7 @@ export const TabContainer = () => {
   };
 
   return (
-    <div className='flex flex-col gap-5 lg:flex-row lg:items-end lg:gap-0'>
+    <div className='flex flex-col gap-5 px-6 lg:flex-row lg:items-end lg:gap-0 lg:px-11.25'>
       <div className='flex w-full flex-col gap-2.5'>
         <div className='overflow-x-scroll [&::-webkit-scrollbar]:hidden'>
           <div role='tablist' className='flex gap-7.5' aria-label='파트 선택'>

--- a/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_containers/TableContainer.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_containers/TableContainer.tsx
@@ -83,7 +83,7 @@ export const TableContainer = () => {
   const half = Math.ceil(specificAttendanceList.length / 2);
 
   return (
-    <>
+    <div className='overflow-scroll [&::-webkit-scrollbar]:hidden'>
       {selectedSessionType === 'FULL' ? (
         <AdminAttendanceEntireTable items={fullAttendanceList} />
       ) : (
@@ -110,6 +110,6 @@ export const TableContainer = () => {
           </div>
         </>
       )}
-    </>
+    </div>
   );
 };

--- a/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_containers/TableContainer.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/attendance/_containers/TableContainer.tsx
@@ -83,7 +83,7 @@ export const TableContainer = () => {
   const half = Math.ceil(specificAttendanceList.length / 2);
 
   return (
-    <div className='overflow-scroll [&::-webkit-scrollbar]:hidden'>
+    <div className='overflow-scroll px-6 lg:px-11.25 [&::-webkit-scrollbar]:hidden'>
       {selectedSessionType === 'FULL' ? (
         <AdminAttendanceEntireTable items={fullAttendanceList} />
       ) : (

--- a/apps/homepage/src/app/(with-header)/mypage/admin/attendance/page.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/attendance/page.tsx
@@ -5,9 +5,11 @@ import {TabContainer} from '@/app/(with-header)/mypage/admin/attendance/_contain
 
 export default function AdminAttendancePage() {
   return (
-    <section className='px-6 lg:px-11.25'>
+    <section>
       <div className='flex w-full flex-col gap-3 overflow-hidden py-10 pb-7.5 lg:gap-4.5 lg:py-13.5 lg:pb-0'>
-        <h1 className='text-h2 hidden text-neutral-800 lg:block'>출석 관리</h1>
+        <h1 className='text-h2 hidden px-11.25 text-neutral-800 lg:block'>
+          출석 관리
+        </h1>
         <DropdownContainer />
         <SuspenseWrapper>
           <TabContainer />

--- a/apps/homepage/src/app/(with-header)/mypage/admin/penalties/_components/row/AdminPenaltiesSpecificTableRow.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/penalties/_components/row/AdminPenaltiesSpecificTableRow.tsx
@@ -38,9 +38,9 @@ export const AdminPenaltiesSpecificTableRow = ({
 
   return (
     <tr className='text-body-l-sb text-center text-neutral-600'>
-      <td className='px-3 py-4'>{row.name}</td>
+      <td className='min-w-max px-3 py-4 whitespace-nowrap'>{row.name}</td>
 
-      <td className='overflow-hidden px-3 py-4'>
+      <td className='min-w-max overflow-hidden px-3 py-4'>
         <StatusChip
           value={row.attendanceResult}
           config={ATTENDANCE_STATUS_CONFIG}
@@ -49,7 +49,7 @@ export const AdminPenaltiesSpecificTableRow = ({
         />
       </td>
 
-      <td className='overflow-hidden px-3 py-4'>
+      <td className='min-w-max overflow-hidden px-3 py-4'>
         <StatusChip
           value={row.beerNetworkingParticipated ? 'PRESENT' : 'ABSENT'}
           config={BEER_NETWORKING_ATTENDANCE_CONFIG}
@@ -64,17 +64,18 @@ export const AdminPenaltiesSpecificTableRow = ({
         />
       </td>
 
-      <td className='px-3 py-4'>
+      <td className='min-w-max px-3 py-4'>
         <input
           type='text'
           placeholder='0'
           aria-label='기타 벌점'
+          size={Math.max(value.length, 1)}
           value={value}
           onChange={(e) => {
             const num = parseInt(e.target.value, 10);
             setValue(isNaN(num) ? String(0) : String(num));
           }}
-          className='text-body-l-sb placeholder:text-body-l-sb w-full bg-transparent text-center text-neutral-600 outline-none placeholder:text-neutral-600'
+          className='text-body-l-sb placeholder:text-body-l-sb min-w-0 bg-transparent text-center text-neutral-600 outline-none placeholder:text-neutral-600'
         />
       </td>
     </tr>

--- a/apps/homepage/src/app/(with-header)/mypage/admin/penalties/_components/table/AdminPenaltiesEntireTable.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/penalties/_components/table/AdminPenaltiesEntireTable.tsx
@@ -14,6 +14,23 @@ import {
   PENALTY_FULL_TABLE_HEADER_MOBILE,
 } from '@/constants/admin/admin-penalties';
 
+const renderHeaderLabel = (label: string) => {
+  if (!label.includes('\n')) return label;
+
+  const lines = label.split('\n');
+
+  return (
+    <span className='whitespace-nowrap'>
+      {lines.map((line, idx) => (
+        <span key={`${line}-${idx}`}>
+          {idx > 0 && <br />}
+          {line}
+        </span>
+      ))}
+    </span>
+  );
+};
+
 interface AdminPenaltiesEntireTableProps {
   items: AdminPenaltiesEntireTableRowType[];
   onSort: () => void;
@@ -40,15 +57,15 @@ export const AdminPenaltiesEntireTable = ({
     : PENALTY_FULL_TABLE_HEADER;
 
   return (
-    <table className='h-fit w-full table-fixed border-collapse'>
+    <table className='table-atuo h-fit w-full border-collapse'>
       <thead className='bg-neutral-200'>
         <tr>
           {tableHeader.map((col) => (
             <th
               key={col.key}
-              className='text-body-m lg:text-body-l-sb py-1 font-bold text-neutral-600 lg:px-3 lg:py-4'>
-              <div className='flex flex-wrap items-center justify-center gap-2.5 whitespace-pre-line'>
-                {col.label}
+              className='text-body-m lg:text-body-l-sb min-w-13.75 py-1 font-bold text-neutral-600 lg:py-4'>
+              <div className='flex flex-wrap items-center justify-center gap-2.5'>
+                {renderHeaderLabel(col.label)}
                 {col.key === ('total-minus-point' as PenaltyFullTableKey) &&
                   (sortedDirection ? (
                     <button
@@ -95,22 +112,22 @@ export const AdminPenaltiesEntireTable = ({
         ) : (
           items.map((row) => (
             <tr key={row.memberId} className='text-body-l-sb'>
-              <td className='px-3 py-4 text-center text-neutral-600'>
+              <td className='min-w-max px-3 py-4 text-center whitespace-nowrap text-neutral-600'>
                 {row.name}
               </td>
-              <td className='text-alert px-3 py-4 text-center'>
+              <td className='text-alert min-w-max px-3 py-4 text-center whitespace-nowrap'>
                 {row.attendanceMinusPoint}
               </td>
-              <td className='text-alert px-3 py-4 text-center'>
+              <td className='text-alert min-w-max px-3 py-4 text-center whitespace-nowrap'>
                 {row.sessionMinusPoint}
               </td>
-              <td className='px-3 py-4 text-center text-neutral-800'>
+              <td className='min-w-max px-3 py-4 text-center whitespace-nowrap text-neutral-800'>
                 {row.beerNetworkingCount}
               </td>
-              <td className='text-secondary px-3 py-4 text-center'>
+              <td className='text-secondary min-w-max px-3 py-4 text-center whitespace-nowrap'>
                 {row.beerNetworkingBonusPoint}
               </td>
-              <td className='px-3 py-4 text-center text-neutral-800'>
+              <td className='min-w-max px-3 py-4 text-center whitespace-nowrap text-neutral-800'>
                 {row.totalMinusPoint}
               </td>
             </tr>

--- a/apps/homepage/src/app/(with-header)/mypage/admin/penalties/_components/table/AdminPenaltiesSpecificTable.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/penalties/_components/table/AdminPenaltiesSpecificTable.tsx
@@ -16,16 +16,14 @@ export const AdminPenaltiesSpecificTable = ({
   onChangeExtraMinusPoint,
 }: AdminPenaltiesSpecificTableProps) => {
   return (
-    <table className='h-fit w-full table-fixed border-collapse'>
+    <table className='h-fit w-full table-auto border-collapse'>
       <thead className='bg-neutral-200'>
         <tr>
           {PENALTY_SPECIFIC_TABLE_HEADER.map((col) => (
             <th
               key={col.key}
-              className='text-body-m lg:text-body-l-sb py-4 font-bold text-neutral-600'>
-              <div className='flex items-center justify-center gap-2.5'>
-                {col.label}
-              </div>
+              className='text-body-m lg:text-body-l-sb min-w-max py-2.5 font-bold whitespace-nowrap text-neutral-600 lg:py-4'>
+              {col.label}
             </th>
           ))}
         </tr>

--- a/apps/homepage/src/app/(with-header)/mypage/admin/penalties/_containers/DropdownContainer.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/penalties/_containers/DropdownContainer.tsx
@@ -103,7 +103,7 @@ export const DropdownContainer = () => {
   };
 
   return (
-    <div className='flex flex-col gap-5 lg:flex-row lg:items-end lg:gap-0'>
+    <div className='flex flex-col gap-5 px-6 lg:flex-row lg:items-end lg:gap-0 lg:px-11.25'>
       <div className='flex gap-5'>
         <Dropdown
           placeholder='기수'

--- a/apps/homepage/src/app/(with-header)/mypage/admin/penalties/_containers/TableContainer.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/penalties/_containers/TableContainer.tsx
@@ -106,7 +106,7 @@ export const TableContainer = () => {
   };
 
   return (
-    <div className='overflow-scroll [&::-webkit-scrollbar]:hidden'>
+    <div className='overflow-scroll px-6 lg:px-11.25 [&::-webkit-scrollbar]:hidden'>
       {selectedSessionType === 'FULL' ? (
         <AdminPenaltiesEntireTable
           items={allStatistics}

--- a/apps/homepage/src/app/(with-header)/mypage/admin/penalties/_containers/TableContainer.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/penalties/_containers/TableContainer.tsx
@@ -106,7 +106,7 @@ export const TableContainer = () => {
   };
 
   return (
-    <>
+    <div className='overflow-scroll [&::-webkit-scrollbar]:hidden'>
       {selectedSessionType === 'FULL' ? (
         <AdminPenaltiesEntireTable
           items={allStatistics}
@@ -123,6 +123,6 @@ export const TableContainer = () => {
           />
         </div>
       )}
-    </>
+    </div>
   );
 };

--- a/apps/homepage/src/app/(with-header)/mypage/admin/penalties/page.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/penalties/page.tsx
@@ -4,9 +4,9 @@ import {TableContainer} from '@/app/(with-header)/mypage/admin/penalties/_contai
 
 export default function AdminPenaltiesPage() {
   return (
-    <section className='px-6 lg:px-11.25'>
+    <section>
       <div className='flex w-full flex-col gap-3 overflow-hidden py-10 pb-7.5 lg:gap-4.5 lg:py-13.5 lg:pb-0'>
-        <h1 className='text-h2 hidden text-neutral-800 lg:block'>
+        <h1 className='text-h2 hidden px-11.25 text-neutral-800 lg:block'>
           상벌점 관리
         </h1>
         <SuspenseWrapper>

--- a/apps/homepage/src/components/layout/CountdownTimer.tsx
+++ b/apps/homepage/src/components/layout/CountdownTimer.tsx
@@ -59,8 +59,8 @@ export const CountdownTimer = ({
   if (isLoading) return <Spinner />;
 
   return (
-    <div className='flex w-fit justify-center gap-10'>
-      <div className='flex flex-col'>
+    <div className='flex w-fit justify-center gap-2.5 lg:gap-7.5'>
+      <div className='flex min-w-15 flex-col'>
         <p
           className={clsx(
             textColor,
@@ -73,11 +73,11 @@ export const CountdownTimer = ({
         </span>
       </div>
 
-      <span className='text-h5 md:text-h1 text-center font-bold text-neutral-400'>
+      <span className='text-h2 lg:text-h5 md:text-h1 text-center leading-[130%] font-bold text-neutral-400 lg:leading-6.5'>
         :
       </span>
 
-      <div className='flex flex-col'>
+      <div className='flex min-w-15 flex-col'>
         <p
           className={clsx(
             textColor,
@@ -90,34 +90,34 @@ export const CountdownTimer = ({
         </span>
       </div>
 
-      <span className='text-h5 md:text-h1 text-center font-bold text-neutral-400'>
+      <span className='text-h2 lg:text-h5 md:text-h1 text-center leading-[130%] font-bold text-neutral-400 lg:leading-6.5'>
         :
       </span>
 
-      <div className='flex flex-col'>
+      <div className='flex min-w-15 flex-col'>
         <p
           className={clsx(
             textColor,
             'text-body-l-b md:text-body-l-sb text-center'
           )}>
-          MINUTE
+          MIN
         </p>
         <span className='text-h5 md:text-h1 text-center font-bold whitespace-nowrap text-neutral-400 tabular-nums'>
           {timeLeft.m}분
         </span>
       </div>
 
-      <span className='text-h5 md:text-h1 text-center font-bold text-neutral-400'>
+      <span className='text-h2 lg:text-h5 md:text-h1 text-center leading-[130%] font-bold text-neutral-400 lg:leading-6.5'>
         :
       </span>
 
-      <div className='flex flex-col'>
+      <div className='flex min-w-15 flex-col'>
         <p
           className={clsx(
             textColor,
             'text-body-l-b md:text-body-l-sb text-center'
           )}>
-          SECOND
+          SEC
         </p>
         <span className='text-h5 md:text-h1 text-center font-bold whitespace-nowrap text-neutral-400 tabular-nums'>
           {timeLeft.s}초

--- a/apps/homepage/src/components/layout/RecruitLayout.tsx
+++ b/apps/homepage/src/components/layout/RecruitLayout.tsx
@@ -43,13 +43,13 @@ export function RecruitLayout({
 
       <div className='flex min-h-fit w-full max-w-152.5 flex-1 flex-col items-center justify-center px-6'>
         <h1
-          className='text-h1 mb-7.5 bg-clip-text text-center text-transparent'
+          className='text-h3 lg:text-h1 mb-7.5 bg-clip-text text-center whitespace-nowrap text-transparent'
           style={{backgroundImage: 'var(--branding-gradient)'}}>
           COde Together, Arrive TOgether
         </h1>
 
         <p
-          className={`text-body-l text-primary mb-1.25 text-center font-semibold`}>
+          className={`text-h5 lg:text-body-l text-primary mb-1.25 text-center font-bold lg:font-semibold`}>
           {isRecruiting
             ? recruitmentText.isInProgressRecruiting.statusText
             : recruitmentText.isDoneRecruiting.statusText}

--- a/apps/recruit/src/app/faq/_components/FaqAccordion.tsx
+++ b/apps/recruit/src/app/faq/_components/FaqAccordion.tsx
@@ -24,7 +24,7 @@ export const FaqAccordion = ({item}: FaqAccordionProps) => {
       <div className='flex w-full items-center justify-between self-stretch'>
         <p
           className={clsx(
-            'text-h5 font-semibold transition-colors duration-300',
+            'text-h5 text-start font-semibold transition-colors duration-300',
             isOpen ? 'text-neutral-800' : 'text-neutral-600'
           )}>
           {item.question}

--- a/apps/recruit/src/app/faq/_components/FaqSideBar.tsx
+++ b/apps/recruit/src/app/faq/_components/FaqSideBar.tsx
@@ -37,7 +37,7 @@ export const FaqSideBar = () => {
                 aria-current={isActive ? 'page' : undefined}>
                 <p
                   className={clsx(
-                    'text-h5 w-36 rounded-[5px] px-2 py-1.25 transition-colors duration-300 lg:w-45.25',
+                    'text-h5 w-36 rounded-[5px] px-2 py-1.25 font-semibold transition-colors duration-300 lg:w-45.25',
                     isActive
                       ? 'bg-neutral-800 text-neutral-100'
                       : 'bg-neutral-50 text-neutral-800 lg:bg-transparent'


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->

#360 

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->

5차 qa에서 진행한 수정사항 체크리스트를 반영했습니다. 

## 텍스트 스타일 수정

|  | 기존 | 수정 후 |
| :-- | :-- | :-- |
| 홈페이지 recruit 페이지 | <img width="384" height="811" alt="image" src="https://github.com/user-attachments/assets/17d9bc02-b0b9-4158-b53b-b67520c8c9bf" /> <img width="384" height="811" alt="image" src="https://github.com/user-attachments/assets/0ad8d57f-d574-4094-bc17-04a1b0de9fe2" /> | <img width="384" height="811" alt="image" src="https://github.com/user-attachments/assets/d5898b58-35af-40dd-b36c-a9460af77016" /> <img width="383" height="810" alt="image" src="https://github.com/user-attachments/assets/07d22e65-c443-4399-80fd-cd9712bd49d4" /> |
| faq 아코디언 | <img width="385" height="813" alt="image" src="https://github.com/user-attachments/assets/a74ae295-143d-4b55-a86e-e64519426984" /> | <img width="382" height="808" alt="image" src="https://github.com/user-attachments/assets/b689d261-d4f5-4021-9cd9-d396f7f3f0ed" /> |

## 드롭다운 그림자 잘리지 않도록 수정

<img width="398" height="100" alt="image" src="https://github.com/user-attachments/assets/60499c82-0320-4717-b05b-25484dff639f" /> 

## 표 가로 스크롤 및 텍스트 스타일 수정 

https://github.com/user-attachments/assets/96143a7c-a42b-4280-a5d7-d93b1f4f3106

<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 홈페이지 서버 : recruit 페이지의 타이머와 주요활동 일정 텍스트 스타일 확인
- [ ] 홈페이지 서버 : 마이페이지 - 출석관리/상벌점 관리 페이지의 모바일 사이즈에서 화면보다 넘치는 표가 가로 스크롤 되는지 확인
- [ ] 홈페이지 서버 : 마이페이지 - 출석관리/상벌점 관리 페이지의 드롭다운 그림자가 잘리지 않는지 확인
- [ ] 리크루트 서버 : faq 페이지의 아코디언 question 텍스트 정렬이 start인지 확인 
