### PR TITLE
[DevOps]: 모노레포 내 폴더 변경에 따른 PR 라벨링 자동화 워크플로우 구축

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,16 @@
+🥔 RECRUIT:
+  - changed-files:
+      - any-glob-to-any-file: 'apps/recruit/**/*'
+
+🥔 HOMEPAGE:
+  - changed-files:
+      - any-glob-to-any-file: 'apps/homepage/**/*'
+
+"🍟 COMMON":
+  - changed-files:
+      # 1. packages 내부의 공통 폴더가 수정되었을 때
+      - any-glob-to-any-file: 'packages/**/*'
+      # 2. apps/recruit과 apps/homepage가 동시에 수정되었을 때
+      - all-globs-to-all-files:
+          - 'apps/recruit/**/*'
+          - 'apps/homepage/**/*'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,8 +1,8 @@
-🥔 RECRUIT:
+"🥔 RECRUIT":
   - changed-files:
       - any-glob-to-any-file: 'apps/recruit/**/*'
 
-🥔 HOMEPAGE:
+"🥔 HOMEPAGE":
   - changed-files:
       - any-glob-to-any-file: 'apps/homepage/**/*'
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,16 +1,18 @@
 name: "Pull Request Labeler"
+
 on:
-  - pull_request_target 
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   label:
     permissions:
       contents: read
-      pull-requests: write 
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v5
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/labeler.yml
-          sync-labels: true 
+          sync-labels: true

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,16 @@
+name: "Pull Request Labeler"
+on:
+  - pull_request_target 
+
+jobs:
+  label:
+    permissions:
+      contents: read
+      pull-requests: write 
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/labeler.yml
+          sync-labels: true 

--- a/apps/homepage/src/app/onboarding/page.tsx
+++ b/apps/homepage/src/app/onboarding/page.tsx
@@ -2,6 +2,7 @@ import {OnboardingContainer} from '@/app/onboarding/_containers/OnboardingContai
 import OnboardingBackground from '@/assets/onboarding/onboarding-background.svg';
 import {CotatoLogo} from '@repo/ui/components/logo/CotatoLogo';
 import clsx from 'clsx';
+
 export default function OnboardingPage() {
   return (
     <section className='relative h-screen w-full overflow-hidden bg-black'>


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->

close #359

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->

모노레포 구조 내의 각 서비스(RECRUIT, HOMEPAGE) 및 공통 패키지(COMMON)의 변경 사항을 자동으로 감지하여 PR에 라벨을 부착하는 GitHub Actions 자동화 기능을 도입했습니다.

## 프로젝트별 경로

*  apps/recruit 변경 시 🥔 RECRUIT 라벨 부착
* apps/homepage 변경 시 🥔 HOMEPAGE 라벨 부착
* packages 내부 혹은 다중 프로젝트 변경 시 🍟 COMMON 라벨 부착
* sync-labels: true 설정: PR 내 파일 수정으로 변경 경로가 달라질 경우 라벨이 실시간으로 동기화되도록 설정

더 추가하고 싶은 자동화 라벨링 있으면 알려주세욤

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->

<img width="408" height="77" alt="image" src="https://github.com/user-attachments/assets/fb3cac48-7e41-4c39-85aa-c437b7ea03a3" />

상단 사진과 같이 액션봇이 어떤 폴더에 위치한 파일이 변경했는질 자동으로 감지하고 라벨링을 부착할 거예요 

<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 라벨링 부착 PR 올렸을 때 제대로 실행되는지!! 확인해주세용 
