### PR TITLE
[FIX]: 홈페이지 5차 QA 수정사항 적용

### DIFF
--- a/apps/homepage/src/app/(with-header)/mypage/admin/approvals/_components/table/ApprovalTableView.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/approvals/_components/table/ApprovalTableView.tsx
@@ -40,90 +40,95 @@ export const ApprovalTableView = ({
 
   return (
     <>
-      <table className='w-full table-fixed border-collapse [border-spacing:0] lg:min-w-277.5 lg:table-auto'>
-        <thead className='bg-neutral-200'>
-          <tr>
-            {APPROVAL_COLUMNS.map((col) => (
-              <th
-                key={col.key}
-                className={clsx(
-                  'text-body-l-sb bg-neutral-200 px-2.5 py-3 text-center align-middle text-neutral-600 lg:px-3 lg:py-4',
-                  (col.key === 'phone' || col.key === 'applicationDate') &&
-                    'hidden lg:table-cell'
-                )}>
-                {col.key === 'name' ? (
+      <div className='w-full overflow-x-auto'>
+        <table className='w-full border-collapse table-fixed [border-spacing:0]'>
+          <thead className='bg-neutral-200'>
+            <tr>
+              {APPROVAL_COLUMNS.map((col) => (
+                <th
+                  key={col.key}
+                  className={clsx(
+                    'text-body-l-sb bg-neutral-200 px-2.5 py-3 text-center align-middle text-neutral-600 lg:px-3 lg:py-4',
+                    (col.key === 'phone' || col.key === 'applicationDate') &&
+                      'hidden lg:table-cell'
+                  )}>
+                  {col.key === 'name' ? (
+                    <div className='flex items-center gap-0.5 px-2'>
+                      <span className='shrink-0'>
+                        <Checkbox
+                          checked={isAllSelected}
+                          onChange={onSelectAll}
+                          className='border-0 bg-neutral-50'
+                        />
+                      </span>
+                      <span className='flex-1 text-center'>이름</span>
+                    </div>
+                  ) : (
+                    col.label
+                  )}
+                </th>
+              ))}
+              <th className='text-body-l-sb px-2.5 py-3 text-center align-middle text-neutral-600 lg:px-3 lg:py-4' />
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((member) => (
+              <tr key={member.memberId} className='text-body-l text-neutral-600'>
+                <td className='truncate px-2.5 py-3 lg:px-3 lg:py-4'>
                   <div className='flex items-center gap-0.5 px-2'>
                     <span className='shrink-0'>
                       <Checkbox
-                        checked={isAllSelected}
-                        onChange={onSelectAll}
+                        checked={selectedIds.includes(member.memberId)}
+                        onChange={(checked) =>
+                          onSelect(member.memberId, checked)
+                        }
                         className='border-0 bg-neutral-50'
                       />
                     </span>
-                    <span className='flex-1 text-center'>이름</span>
+                    <span className='flex-1 text-center'>{member.name}</span>
                   </div>
-                ) : (
-                  col.label
-                )}
-              </th>
+                </td>
+                <td className='truncate px-2.5 py-3 text-center lg:px-3 lg:py-4'>
+                  {member.passedGenerationNumber}기
+                </td>
+                <td className='truncate px-2.5 py-3 text-center lg:px-3 lg:py-4'>
+                  {MEMBER_POSITION_LABEL[
+                    member.position as MemberPositionKey
+                  ] ?? member.position}
+                </td>
+                <td className='hidden truncate px-2.5 py-3 text-center lg:table-cell lg:px-3 lg:py-4'>
+                  {member.phoneNumber}
+                </td>
+                <td className='hidden truncate px-2.5 py-3 text-center lg:table-cell lg:px-3 lg:py-4'>
+                  {new Date(member.appliedAt).toLocaleDateString('ko-KR', {
+                    year: 'numeric',
+                    month: '2-digit',
+                    day: '2-digit',
+                  })}
+                </td>
+                <td className='px-2.5 py-3 lg:px-3 lg:py-4'>
+                  <div className='flex items-center justify-center gap-0.5 lg:gap-2.5'>
+                    <button
+                      type='button'
+                      disabled={isLoading}
+                      onClick={() => onApprove(member.memberId)}
+                      className='text-primary text-body-m-sb cursor-pointer rounded-lg bg-neutral-50 px-1.5 py-px whitespace-nowrap lg:px-4.5 lg:py-0.75'>
+                      {approveLabel}
+                    </button>
+                    <button
+                      type='button'
+                      disabled={isLoading}
+                      onClick={() => onReject(member.memberId)}
+                      className='text-body-m-sb cursor-pointer rounded-lg bg-neutral-50 px-1.5 py-px whitespace-nowrap text-neutral-600 lg:px-4.5 lg:py-0.75'>
+                      {rejectLabel}
+                    </button>
+                  </div>
+                </td>
+              </tr>
             ))}
-            <th className='text-body-l-sb px-2.5 py-3 text-center align-middle text-neutral-600 lg:px-3 lg:py-4' />
-          </tr>
-        </thead>
-        <tbody>
-          {items.map((member) => (
-            <tr key={member.memberId} className='text-body-l text-neutral-600'>
-              <td className='truncate px-2.5 py-3 lg:px-3 lg:py-4'>
-                <div className='flex items-center gap-0.5 px-2'>
-                  <span className='shrink-0'>
-                    <Checkbox
-                      checked={selectedIds.includes(member.memberId)}
-                      onChange={(checked) => onSelect(member.memberId, checked)}
-                      className='border-0 bg-neutral-50'
-                    />
-                  </span>
-                  <span className='flex-1 text-center'>{member.name}</span>
-                </div>
-              </td>
-              <td className='truncate px-2.5 py-3 text-center lg:px-3 lg:py-4'>
-                {member.passedGenerationNumber}기
-              </td>
-              <td className='truncate px-2.5 py-3 text-center lg:px-3 lg:py-4'>
-                {MEMBER_POSITION_LABEL[member.position as MemberPositionKey] ??
-                  member.position}
-              </td>
-              <td className='hidden truncate px-2.5 py-3 text-center lg:table-cell lg:px-3 lg:py-4'>
-                {member.phoneNumber}
-              </td>
-              <td className='hidden truncate px-2.5 py-3 text-center lg:table-cell lg:px-3 lg:py-4'>
-                {new Date(member.appliedAt).toLocaleDateString('ko-KR', {
-                  year: 'numeric',
-                  month: '2-digit',
-                  day: '2-digit',
-                })}
-              </td>
-              <td className='px-2.5 py-3 lg:px-3 lg:py-4'>
-                <div className='flex items-center justify-center gap-0.5 lg:gap-2.5'>
-                  <button
-                    type='button'
-                    disabled={isLoading}
-                    onClick={() => onApprove(member.memberId)}
-                    className='text-primary text-body-m-sb cursor-pointer rounded-lg bg-neutral-50 px-2 py-px whitespace-nowrap lg:px-4.5 lg:py-0.75'>
-                    {approveLabel}
-                  </button>
-                  <button
-                    type='button'
-                    disabled={isLoading}
-                    onClick={() => onReject(member.memberId)}
-                    className='text-body-m-sb cursor-pointer rounded-lg bg-neutral-50 px-2 py-px whitespace-nowrap text-neutral-600 lg:px-4.5 lg:py-0.75'>
-                    {rejectLabel}
-                  </button>
-                </div>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+          </tbody>
+        </table>
+      </div>
       <SelectedMembersBar
         selectedIds={selectedIds}
         allItems={allItems}

--- a/apps/homepage/src/app/(with-header)/mypage/admin/users/_components/table/AdminUsersTableView.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/users/_components/table/AdminUsersTableView.tsx
@@ -65,150 +65,155 @@ export const AdminUsersTableView = ({
 
   return (
     <>
-      <table className='w-full table-fixed border-collapse [border-spacing:0] lg:min-w-277.5 lg:table-auto'>
-        <thead className='bg-neutral-200'>
-          <tr>
-            {MEMBER_COLUMNS.map((col) => {
-              const isStatusColumn = col.key === 'status';
-              const isNameColumn = col.key === 'name';
-              return (
-                <th
-                  key={col.key}
-                  className={clsx(
-                    'text-body-m lg:text-body-l border-0 bg-neutral-200 py-3 text-center align-middle font-semibold text-neutral-600 lg:px-3 lg:py-4',
-                    (col.key === 'school' || col.key === 'phone') &&
-                      'hidden lg:table-cell'
-                  )}>
-                  {isNameColumn && isAllTab ? (
-                    <div className='flex items-center gap-0.5 px-2'>
+      <div className='w-full overflow-x-auto'>
+        <table className='w-full table-fixed border-collapse [border-spacing:0] lg:min-w-277.5 lg:table-auto'>
+          <thead className='bg-neutral-200'>
+            <tr>
+              {MEMBER_COLUMNS.map((col) => {
+                const isStatusColumn = col.key === 'status';
+                const isNameColumn = col.key === 'name';
+                return (
+                  <th
+                    key={col.key}
+                    className={clsx(
+                      'text-body-m lg:text-body-l border-0 bg-neutral-200 py-3 text-center align-middle font-semibold text-neutral-600 lg:px-3 lg:py-4',
+                      (col.key === 'school' || col.key === 'phone') &&
+                        'hidden lg:table-cell'
+                    )}>
+                    {isNameColumn && isAllTab ? (
+                      <div className='flex items-center gap-0.5 px-2'>
+                        <span className='shrink-0'>
+                          <Checkbox
+                            checked={isAllSelected}
+                            onChange={onSelectAll}
+                            className='border-0 bg-neutral-50'
+                          />
+                        </span>
+                        <span className='flex-1 text-center'>이름</span>
+                      </div>
+                    ) : (
+                      <div className='flex items-center justify-center gap-2.5'>
+                        <div>
+                          {isStatusColumn && !isAllTab ? '역할' : col.label}
+                        </div>
+                        {isStatusColumn && isAllTab && (
+                          <div
+                            ref={filterRef}
+                            className='relative flex items-center'>
+                            <button
+                              type='button'
+                              onClick={() => setIsFilterOpen(!isFilterOpen)}
+                              aria-label='활동여부 필터 토글'
+                              className='cursor-pointer'>
+                              {selectedStatuses.length > 0 ? (
+                                <FinishFilterIcon />
+                              ) : (
+                                <DefaultFilterIcon />
+                              )}
+                            </button>
+                            {isFilterOpen && (
+                              <div className='absolute top-full left-0 z-50 mt-2 w-27 -translate-x-3/4'>
+                                <CheckboxFilter
+                                  options={MEMBER_STATUS_OPTIONS}
+                                  selected={selectedStatuses}
+                                  onChange={onFilterChange}
+                                  onClose={() => setIsFilterOpen(false)}
+                                  getLabel={(key) =>
+                                    MEMBER_STATUS_CONFIG[key].label
+                                  }
+                                />
+                              </div>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </th>
+                );
+              })}
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((member) => (
+              <tr
+                key={member.memberId}
+                className='text-body-m lg:text-body-l text-neutral-600'>
+                <td className='truncate border-0 px-2.5 py-3 lg:px-3 lg:py-4'>
+                  <div className='flex items-center gap-0.5 px-2'>
+                    {isAllTab && (
                       <span className='shrink-0'>
                         <Checkbox
-                          checked={isAllSelected}
-                          onChange={onSelectAll}
+                          checked={selectedIds.includes(member.memberId)}
+                          onChange={(checked) =>
+                            onSelect(member.memberId, checked)
+                          }
                           className='border-0 bg-neutral-50'
                         />
                       </span>
-                      <span className='flex-1 text-center'>이름</span>
-                    </div>
-                  ) : (
-                    <div className='flex items-center justify-center gap-2.5'>
-                      <div>
-                        {isStatusColumn && !isAllTab ? '역할' : col.label}
-                      </div>
-                      {isStatusColumn && isAllTab && (
-                        <div
-                          ref={filterRef}
-                          className='relative flex items-center'>
-                          <button
-                            type='button'
-                            onClick={() => setIsFilterOpen(!isFilterOpen)}
-                            aria-label='활동여부 필터 토글'
-                            className='cursor-pointer'>
-                            {selectedStatuses.length > 0 ? (
-                              <FinishFilterIcon />
-                            ) : (
-                              <DefaultFilterIcon />
-                            )}
-                          </button>
-                          {isFilterOpen && (
-                            <div className='absolute top-full left-0 z-50 mt-2 w-27 -translate-x-3/4'>
-                              <CheckboxFilter
-                                options={MEMBER_STATUS_OPTIONS}
-                                selected={selectedStatuses}
-                                onChange={onFilterChange}
-                                onClose={() => setIsFilterOpen(false)}
-                                getLabel={(key) =>
-                                  MEMBER_STATUS_CONFIG[key].label
-                                }
-                              />
-                            </div>
-                          )}
-                        </div>
-                      )}
-                    </div>
-                  )}
-                </th>
-              );
-            })}
-          </tr>
-        </thead>
-        <tbody>
-          {items.map((member) => (
-            <tr
-              key={member.memberId}
-              className='text-body-m lg:text-body-l text-neutral-600'>
-              <td className='truncate border-0 px-2.5 py-3 lg:px-3 lg:py-4'>
-                <div className='flex items-center gap-0.5 px-2'>
-                  {isAllTab && (
-                    <span className='shrink-0'>
-                      <Checkbox
-                        checked={selectedIds.includes(member.memberId)}
-                        onChange={(checked) =>
-                          onSelect(member.memberId, checked)
+                    )}
+                    <span className='flex-1 text-center'>{member.name}</span>
+                  </div>
+                </td>
+                <td className='truncate border-0 py-3 text-center lg:px-3 lg:py-4'>
+                  {member.passedGenerationNumber}기
+                </td>
+                <td className='truncate border-0 py-3 text-center lg:px-3 lg:py-4'>
+                  {MEMBER_POSITION_LABEL[
+                    member.position as MemberPositionKey
+                  ] ?? member.position}
+                </td>
+                <td className='hidden truncate border-0 py-3 text-center lg:table-cell lg:px-3 lg:py-4'>
+                  {member.university}
+                </td>
+                <td className='hidden truncate border-0 py-3 text-center lg:table-cell lg:px-3 lg:py-4'>
+                  {formatPhoneNumber(member.phoneNumber)}
+                </td>
+                <td className='border-0 px-2.5 py-3 lg:px-3 lg:py-4'>
+                  <div className='flex items-center justify-center lg:gap-2'>
+                    {isAllTab ? (
+                      <StatusDropdown
+                        key={`${member.memberId}-status`}
+                        value={member.status as MemberStatusKey}
+                        options={MEMBER_STATUS_OPTIONS}
+                        config={MEMBER_STATUS_CONFIG}
+                        onChange={(value) =>
+                          onStatusChange(member.memberId, value)
                         }
-                        className='border-0 bg-neutral-50'
+                        disabled={false}
+                        ariaLabel='활동여부 선택'
+                        wrapperClassName='w-[61px] lg:w-18.75'
                       />
-                    </span>
-                  )}
-                  <span className='flex-1 text-center'>{member.name}</span>
-                </div>
-              </td>
-              <td className='truncate border-0 py-3 text-center lg:px-3 lg:py-4'>
-                {member.passedGenerationNumber}기
-              </td>
-              <td className='truncate border-0 py-3 text-center lg:px-3 lg:py-4'>
-                {MEMBER_POSITION_LABEL[member.position as MemberPositionKey] ??
-                  member.position}
-              </td>
-              <td className='hidden truncate border-0 py-3 text-center lg:table-cell lg:px-3 lg:py-4'>
-                {member.university}
-              </td>
-              <td className='hidden truncate border-0 py-3 text-center lg:table-cell lg:px-3 lg:py-4'>
-                {formatPhoneNumber(member.phoneNumber)}
-              </td>
-              <td className='border-0 px-2.5 py-3 lg:px-3 lg:py-4'>
-                <div className='flex items-center justify-center lg:gap-2'>
-                  {isAllTab ? (
-                    <StatusDropdown
-                      key={`${member.memberId}-status`}
-                      value={member.status as MemberStatusKey}
-                      options={MEMBER_STATUS_OPTIONS}
-                      config={MEMBER_STATUS_CONFIG}
-                      onChange={(value) =>
-                        onStatusChange(member.memberId, value)
+                    ) : (
+                      <StatusDropdown
+                        key={`${member.memberId}-role`}
+                        value={member.role as MemberRoleKey}
+                        options={MEMBER_ROLE_OPTIONS}
+                        config={MEMBER_ROLE_CONFIG}
+                        onChange={(value) =>
+                          onRoleChange?.(member.memberId, value)
+                        }
+                        disabled={false}
+                        ariaLabel='역할 선택'
+                        wrapperClassName='w-[61px] lg:w-18.75'
+                      />
+                    )}
+                    <ActionMenu
+                      items={
+                        isAllTab
+                          ? ALL_USERS_MENU_ITEMS
+                          : REGULAR_MEMBER_MENU_ITEMS
                       }
-                      disabled={false}
-                      ariaLabel='활동여부 선택'
-                      wrapperClassName='w-[61px] lg:w-18.75'
-                    />
-                  ) : (
-                    <StatusDropdown
-                      key={`${member.memberId}-role`}
-                      value={member.role as MemberRoleKey}
-                      options={MEMBER_ROLE_OPTIONS}
-                      config={MEMBER_ROLE_CONFIG}
-                      onChange={(value) =>
-                        onRoleChange?.(member.memberId, value)
+                      onAction={(action) =>
+                        onMenuAction(action, member.memberId)
                       }
-                      disabled={false}
-                      ariaLabel='역할 선택'
-                      wrapperClassName='w-[61px] lg:w-18.75'
                     />
-                  )}
-                  <ActionMenu
-                    items={
-                      isAllTab
-                        ? ALL_USERS_MENU_ITEMS
-                        : REGULAR_MEMBER_MENU_ITEMS
-                    }
-                    onAction={(action) => onMenuAction(action, member.memberId)}
-                  />
-                </div>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
       {isAllTab && (
         <SelectedMembersBar
           selectedIds={selectedIds}

--- a/apps/homepage/src/app/(with-header)/mypage/admin/users/_hooks/useActiveMembersTable.ts
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/users/_hooks/useActiveMembersTable.ts
@@ -1,5 +1,6 @@
+import {useEffect, useMemo} from 'react';
 import {MemberType} from '@/schemas/admin/admin-members.schema';
-import {useActiveMembersQuery} from '@/hooks/queries/useAdminMembers.query';
+import {useInfiniteActiveMembersQuery} from '@/hooks/queries/useAdminMembers.query';
 import {usePatchActiveMemberRole} from '@/hooks/mutations/useAdminActiveMembers.mutation';
 import {useActiveMembersUrlState} from '@/app/(with-header)/mypage/admin/users/_hooks/useActiveMembersUrlState';
 import {useActiveMembersGeneration} from '@/app/(with-header)/mypage/admin/users/_hooks/useActiveMembersGeneration';
@@ -10,27 +11,47 @@ export const useActiveMembersTable = () => {
   const urlState = useActiveMembersUrlState();
   const generation = useActiveMembersGeneration();
   const isGenerationReady = generation.selectedGeneration !== null;
-  const {data, isLoading: isQueryLoading} = useActiveMembersQuery(
+
+  const {
+    data,
+    isLoading: isQueryLoading,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteActiveMembersQuery(
     {
       generationId: generation.selectedGeneration ?? 0,
-      page: 0,
-      size: 1000,
+      size: 100, // 청크 단위로 분할 Fetch
     },
     isGenerationReady
   );
 
-  // 기수가 아직 결정되지 않았으면 로딩 중으로 처리
-  const isLoading = !isGenerationReady || isQueryLoading;
+  // 모든 데이터를 확보할 때까지 자동으로 다음 페이지 Fetch (리뷰어 Option B안)
+  useEffect(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  // 기수가 아직 결정되지 않았거나 데이터를 가져오는 중이면 로딩 중으로 처리
+  const isLoading = !isGenerationReady || (isQueryLoading && !data);
+
   const keyword = urlState.searchParam?.toLowerCase() ?? '';
-  const allMembers: MemberType[] = data?.content ?? [];
-  const filteredMembers: MemberType[] = keyword
-    ? allMembers.filter(
-        (m) =>
-          m.name.toLowerCase().includes(keyword) ||
-          m.university.toLowerCase().includes(keyword) ||
-          m.position.toLowerCase().includes(keyword)
-      )
-    : allMembers;
+
+  // 확보된 모든 페이지의 데이터를 하나로 통합
+  const allMembers: MemberType[] = useMemo(() => {
+    return data?.pages.flatMap((page) => page?.content ?? []) ?? [];
+  }, [data]);
+
+  const filteredMembers: MemberType[] = useMemo(() => {
+    if (!keyword) return allMembers;
+    return allMembers.filter(
+      (m) =>
+        m.name.toLowerCase().includes(keyword) ||
+        m.university.toLowerCase().includes(keyword) ||
+        m.position.toLowerCase().includes(keyword)
+    );
+  }, [allMembers, keyword]);
 
   const isCurrentGeneration =
     generation.selectedGeneration !== null &&
@@ -38,10 +59,15 @@ export const useActiveMembersTable = () => {
 
   const pageSize = 10;
   const totalPages = Math.ceil(filteredMembers.length / pageSize) || 1;
-  const members = filteredMembers.slice(
-    (urlState.currentPage - 1) * pageSize,
-    urlState.currentPage * pageSize
-  );
+
+  const clampedPage = Math.max(1, Math.min(urlState.currentPage, totalPages));
+
+  const members = useMemo(() => {
+    return filteredMembers.slice(
+      (clampedPage - 1) * pageSize,
+      clampedPage * pageSize
+    );
+  }, [filteredMembers, clampedPage, pageSize]);
 
   const modals = useActiveMembersModals({members, isCurrentGeneration});
   const {mutate: patchRoleMutate} = usePatchActiveMemberRole();
@@ -58,7 +84,7 @@ export const useActiveMembersTable = () => {
   return {
     members,
     totalPages,
-    isLoading,
+    isLoading: isLoading || isFetchingNextPage,
     handleRoleChange,
     ...urlState,
     ...generation,

--- a/apps/homepage/src/app/(with-header)/mypage/admin/users/_hooks/useActiveMembersTable.ts
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/users/_hooks/useActiveMembersTable.ts
@@ -13,8 +13,8 @@ export const useActiveMembersTable = () => {
   const {data, isLoading: isQueryLoading} = useActiveMembersQuery(
     {
       generationId: generation.selectedGeneration ?? 0,
-      page: urlState.currentPage - 1,
-      size: 10,
+      page: 0,
+      size: 1000,
     },
     isGenerationReady
   );
@@ -23,7 +23,7 @@ export const useActiveMembersTable = () => {
   const isLoading = !isGenerationReady || isQueryLoading;
   const keyword = urlState.searchParam?.toLowerCase() ?? '';
   const allMembers: MemberType[] = data?.content ?? [];
-  const members: MemberType[] = keyword
+  const filteredMembers: MemberType[] = keyword
     ? allMembers.filter(
         (m) =>
           m.name.toLowerCase().includes(keyword) ||
@@ -31,10 +31,17 @@ export const useActiveMembersTable = () => {
           m.position.toLowerCase().includes(keyword)
       )
     : allMembers;
+
   const isCurrentGeneration =
     generation.selectedGeneration !== null &&
     generation.selectedGeneration === generation.defaultGenerationId;
-  const totalPages = data?.totalPages ?? 1;
+
+  const pageSize = 10;
+  const totalPages = Math.ceil(filteredMembers.length / pageSize) || 1;
+  const members = filteredMembers.slice(
+    (urlState.currentPage - 1) * pageSize,
+    urlState.currentPage * pageSize
+  );
 
   const modals = useActiveMembersModals({members, isCurrentGeneration});
   const {mutate: patchRoleMutate} = usePatchActiveMemberRole();

--- a/apps/homepage/src/hooks/queries/useAdminMembers.query.ts
+++ b/apps/homepage/src/hooks/queries/useAdminMembers.query.ts
@@ -15,7 +15,6 @@ export const useAdminMembersQuery = (params: GetAdminMembersParams) => {
   return useQuery({
     queryKey: QUERY_KEYS.ADMIN_MEMBERS.LIST(params),
     queryFn: () => getAdminMembers(params),
-    placeholderData: (prev) => prev,
   });
 };
 
@@ -36,7 +35,6 @@ export const useActiveMembersQuery = (
   return useQuery({
     queryKey: QUERY_KEYS.ADMIN_MEMBERS.ACTIVE_LIST(params),
     queryFn: () => getActiveMembers(params),
-    placeholderData: (prev) => prev,
     enabled,
   });
 };

--- a/apps/homepage/src/hooks/queries/useAdminMembers.query.ts
+++ b/apps/homepage/src/hooks/queries/useAdminMembers.query.ts
@@ -1,4 +1,4 @@
-import {useQuery} from '@tanstack/react-query';
+import {useQuery, useInfiniteQuery} from '@tanstack/react-query';
 import {QUERY_KEYS} from '@/constants/query-keys';
 import {
   getAdminMemberDetail,
@@ -35,6 +35,25 @@ export const useActiveMembersQuery = (
   return useQuery({
     queryKey: QUERY_KEYS.ADMIN_MEMBERS.ACTIVE_LIST(params),
     queryFn: () => getActiveMembers(params),
+    enabled,
+  });
+};
+
+/** 활동 회원 목록 무한 스크롤 조회 (전체 데이터 확보용) */
+export const useInfiniteActiveMembersQuery = (
+  params: Omit<GetActiveMembersParams, 'page'>,
+  enabled = true
+) => {
+  return useInfiniteQuery({
+    queryKey: QUERY_KEYS.ADMIN_MEMBERS.ACTIVE_LIST({
+      ...params,
+      type: 'infinite',
+    }),
+    queryFn: ({pageParam = 0}) =>
+      getActiveMembers({...params, page: pageParam}),
+    getNextPageParam: (lastPage) =>
+      lastPage?.hasNext ? lastPage.page + 1 : undefined,
+    initialPageParam: 0,
     enabled,
   });
 };

--- a/apps/homepage/src/schemas/admin/admin-members.schema.ts
+++ b/apps/homepage/src/schemas/admin/admin-members.schema.ts
@@ -117,6 +117,7 @@ export type GetAdminMembersParams = {
 };
 
 export type GetActiveMembersParams = {
+  search?: string;
   generationId: number;
   page?: number;
   size?: number;


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->
close #365 
<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->
- 전체 검색 지원: 서버 API가 활동 회원 검색 기능을 따로 지원하지 않아 현재 페이지에서만 검색되던 버그를 고쳤습니다. 기수 전체 데이터를 한 번에 가져와 클라이언트 측에서 페이지네이션과 필터링을 처리하도록 바꿔서, 모든 페이지의 회원을 검색할 수 있습니다.

- 사실 기존에도 문제가 없었던 것 같은데요,
실시간 데이터 동기화: 회원 제외/수정 작업 후 화면에 이전 데이터가 남지 않도록 쿼리의 placeholderData 옵션을 제거했습니다. 이제 작업 완료 후 즉시 최신 상태가 반영됩니다.

- 테이블 레이아웃 최적화
<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->
<img width="1482" height="1816" alt="화면 기록 2026-04-27 오전 1 52 57" src="https://github.com/user-attachments/assets/1af610b1-a800-4b53-8d33-908ea4cb0bb5" />

<img width="1482" height="1816" alt="화면 기록 2026-04-27 오전 1 53 35" src="https://github.com/user-attachments/assets/f2147397-9643-4b4f-b130-14a2e36a9c0f" />

<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 활동 회원 검색 시 페이지 이동 없이 확인 가능한지 체크
- [ ] 회원 제외하기 이후 즉시 최신 상태 반영 체크
- [ ] 가입 승인 페이지 테이블 overflow 제한 안걸리던 문제 체크
