### PR TITLE
[FIX]: 리쿠르트 면접 확인란 스타일 문제 (QA)

### DIFF
--- a/apps/recruit/src/app/my-page/_containers/MyPageSubmittedApplicationsContainer.tsx
+++ b/apps/recruit/src/app/my-page/_containers/MyPageSubmittedApplicationsContainer.tsx
@@ -10,7 +10,9 @@ import {useRouter} from 'next/navigation';
 
 export const MyPageSubmittedApplicationsContainer = () => {
   const router = useRouter();
+
   const {data: applications, isLoading, isError} = useSubmittedApplications();
+
   const setSelectedId = useApplicationStore((state) => state.setSelectedId);
 
   const handleApplicationClick = (id: number) => {
@@ -24,6 +26,7 @@ export const MyPageSubmittedApplicationsContainer = () => {
         <Spinner />
       </div>
     );
+
   if (isError)
     return (
       <div className='text-alert py-20 text-center'>

--- a/apps/recruit/src/app/my-page/detail/_containers/MyPageApplicationDetailContainer.tsx
+++ b/apps/recruit/src/app/my-page/detail/_containers/MyPageApplicationDetailContainer.tsx
@@ -19,8 +19,10 @@ import {ROUTES} from '@/constants/routes';
 export const MyPageApplicationDetailContainer = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
+
   const {selectedId: applicationId} = useApplicationStore();
 
+  /** 지원서 ID가 없을 경우 마이페이지 메인으로 리다이렉트 */
   useEffect(() => {
     if (!applicationId) {
       router.replace(ROUTES.MYPAGE);

--- a/apps/recruit/src/components/application/EtcQuestionView.tsx
+++ b/apps/recruit/src/components/application/EtcQuestionView.tsx
@@ -41,7 +41,7 @@ export const EtcQuestionView = ({
       />
 
       <div>
-        <FormInput
+        <FormTextarea
           readOnly
           label={`${etcQuestions.interviewStartDate}부터 ${etcQuestions.interviewEndDate}까지 면접이 진행됩니다. 참여가 불가능한 시간이 있다면 모두 작성해 주세요.`}
           value={etcQuestions.unavailableInterviewTimes ?? '-'}


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->

close #363 

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->
기존 문제가 되었던 면접 칸 사진
<img width="828" height="1792" alt="image" src="https://github.com/user-attachments/assets/064522c1-5235-424c-b8d3-565693194704" />


해결한 사진
<img width="305" height="512" alt="image" src="https://github.com/user-attachments/assets/0a81eee3-93ec-4f5a-bd7e-516385c17abf" />
 
기존 `FormInput.tsx` 컴포넌트로 구현되어 있어 글자를 길게 쓸 경우에 대한 대비가 안 되어 있는 문제를 해결하기 위해 면접 인풋 란을 `FormTextArea.tsx` 컴포넌트로 대체했습니다

일반 유저가 마이페이지로 지원서를 확인할 경우 + 어드민 유저가 지원서 열람할 경우 3번째 페이지 렌더링 `EtcQuestionView.tsx` 공용 컴포넌트를 대체하여 해당하는 페이지 모두에 적용됩니다


<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 지원서 확인 UI 