### PR TITLE
[FIX]: 프로젝트 카드 캐러셀 전환 애니메이션 불일치 문제 해결

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,4 @@
+{
+  "spinnerTipsEnabled": true,
+  "prefersReducedMotion": true
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,91 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+### Root (Turborepo monorepo — use from root)
+
+```bash
+pnpm dev              # Run all apps (homepage :3001, recruit :3000)
+pnpm dev:home         # Homepage only
+pnpm dev:recruit      # Recruit only
+pnpm build            # Build all apps
+pnpm lint             # Lint all packages
+pnpm check-types      # TypeScript check across monorepo
+pnpm format           # Prettier format all .ts/.tsx/.md files
+```
+
+### UI package (packages/ui)
+
+```bash
+pnpm dev:components   # Watch mode for shared components
+pnpm dev:styles       # Watch mode for Tailwind CSS
+```
+
+## Architecture
+
+**pnpm workspace + Turborepo monorepo** with two Next.js 16 apps sharing a UI library.
+
+```
+apps/
+  homepage/   # cotato.kr — main website
+  recruit/    # recruit.cotato.kr — recruitment platform
+packages/
+  ui/               # Shared component library (@repo/ui)
+  tailwind-config/  # Shared Tailwind theme
+  typescript-config/# Shared tsconfig variants (nextjs / react-library / base)
+  eslint-config/    # Shared ESLint rules
+```
+
+Both apps use **Next.js App Router** with route groups for layout composition:
+
+- `(with-header)/(with-footer)/(home)/page.tsx` — nested layouts via parenthesized folders
+- `@` alias resolves to `src/` within each app
+
+### Data flow
+
+- **Server state**: TanStack Query v5 — custom hooks in `hooks/mutations/use*.mutation.ts` and `hooks/queries/`; query identifiers centralized in `constants/queryKeys.ts`
+- **Client state**: Zustand v5 — stores in `store/use*.ts` (e.g., auth, admin)
+- **API layer**: Axios clients in `services/api/*.api.ts`
+- **Validation**: Zod v4 schemas in `schemas/*.schema.ts`, consumed via React Hook Form + `@hookform/resolvers`
+
+### Auth & routing
+
+- `ProtectedRoute` component wraps role-gated pages (roles: `ADMIN`, `MEMBER`)
+- Token management via `services/utils/tokenManager`
+- Route constants centralized in `constants/routes.ts`
+
+### Shared UI (@repo/ui)
+
+Import from `@repo/ui`. Key exports: `Button`, `FullButton`, `FormInput`, `FormTextarea`, `FormFile`, `FormSelect`, `Modal`, `StatusDropdown`, `CheckboxFilter`, `Pagination`, `StatusChip`, `HeroMainBanner`.
+
+## Conventions
+
+### File naming
+
+| Type                          | Convention            | Example                                                |
+| ----------------------------- | --------------------- | ------------------------------------------------------ |
+| Components                    | PascalCase            | `HomeClient.tsx`                                       |
+| Hooks / stores / utils        | camelCase             | `useAuthStore.ts`                                      |
+| API / mutation / schema files | camelCase with suffix | `auth.api.ts`, `useAuth.mutation.ts`, `auth.schema.ts` |
+| Folders, assets, icons        | kebab-case            | `mock-faq.ts`, `brand-logo.svg`                        |
+
+### Component declarations
+
+- Pages and layouts: `export default function`
+- All other components: `export const ComponentName = () => { }`
+
+### Git
+
+- Branch: `prefix/scope/issue-number-description` (e.g., `fix/recruit/363-mypage-fix`)
+- Commit: `prefix(scope): description (#issue-number)` (e.g., `fix(recruit): 버그 수정 (#363)`)
+- Prefixes: `feat` `fix` `refactor` `hotfix` `docs` `chore`
+- Scopes: `recruit` `homepage` `root`
+- Husky pre-commit runs ESLint + Prettier auto-fix; commitlint validates message format
+
+### Code style
+
+- ESLint `max-warnings: 0` — zero warnings allowed
+- Prettier: `singleQuote: true`, `printWidth: 80`, Tailwind class ordering via plugin
+- Device-specific layouts go in `_desktop/` and `_mobile/` sub-folders when needed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,3 +89,10 @@ Import from `@repo/ui`. Key exports: `Button`, `FullButton`, `FormInput`, `FormT
 - ESLint `max-warnings: 0` — zero warnings allowed
 - Prettier: `singleQuote: true`, `printWidth: 80`, Tailwind class ordering via plugin
 - Device-specific layouts go in `_desktop/` and `_mobile/` sub-folders when needed
+
+### Pull Requests
+
+- **Template Compliance**: Before creating a Pull Request, always read and strictly follow the format defined in `.github/PULL_REQUEST_TEMPLATE.md`.
+- **Content**: Ensure all sections (Description, Key Changes, Screenshots, etc.) are populated based on the current changes.
+- **Checklists**: Mark checkboxes as completed only if the criteria are genuinely met.
+- **Automation**: When using `gh pr create`, use the template content for the `--body` or `--body-file` flag.

--- a/apps/homepage/src/app/(with-header)/(with-footer)/about-us/_desktop/_containers/AboutUsDesktopProjectContainer.tsx
+++ b/apps/homepage/src/app/(with-header)/(with-footer)/about-us/_desktop/_containers/AboutUsDesktopProjectContainer.tsx
@@ -17,6 +17,19 @@ export const AboutUsDesktopProjectContainer = ({
 
   return (
     <div className='relative flex h-125 w-full max-w-360 items-center justify-center overflow-visible perspective-distant'>
+      <button
+        onClick={() => setIndex((prev) => Math.max(0, prev - 1))}
+        className='absolute top-0 left-0 z-20 h-full w-[calc(50%-218px)] cursor-pointer bg-transparent'
+        aria-label='이전 프로젝트'
+      />
+      <button
+        onClick={() =>
+          setIndex((prev) => Math.min(projects.length - 1, prev + 1))
+        }
+        className='absolute top-0 right-0 z-20 h-full w-[calc(50%-218px)] cursor-pointer bg-transparent'
+        aria-label='다음 프로젝트'
+      />
+
       <div className='relative flex h-full w-full items-center justify-center transform-3d'>
         {projects.map((project, i) => {
           const offset = i - index;
@@ -44,43 +57,37 @@ export const AboutUsDesktopProjectContainer = ({
                 height: '437px',
                 zIndex: 10 - absOffset,
                 transformStyle: 'preserve-3d',
+                pointerEvents: 'none',
               }}
               className='rounded-[20px]'>
-              <div className='relative h-full w-full'>
-                <button
-                  onClick={() => setIndex(i)}
-                  className='absolute inset-0 z-50 h-full w-full cursor-pointer border-none bg-transparent outline-none'
-                  aria-label={`${project.title} 선택`}
+              <div className='pointer-events-none relative h-full w-full overflow-hidden rounded-[20px] bg-white shadow-2xl'>
+                <Image
+                  src={project.imageSrc}
+                  alt=''
+                  fill
+                  sizes='436px'
+                  className='object-cover'
+                  priority={isActive}
+                  unoptimized={true}
                 />
-                <div className='pointer-events-none relative h-full w-full overflow-hidden rounded-[20px] bg-white shadow-2xl'>
-                  <Image
-                    src={project.imageSrc}
-                    alt=''
-                    fill
-                    sizes='436px'
-                    className='object-cover'
-                    priority={isActive}
-                    unoptimized={true}
-                  />
 
-                  {!isActive && (
-                    <div className='absolute inset-0 bg-black opacity-40' />
+                {!isActive && (
+                  <div className='absolute inset-0 bg-black opacity-40' />
+                )}
+
+                <AnimatePresence>
+                  {isActive && (
+                    <motion.div
+                      initial={{opacity: 0, y: 20}}
+                      animate={{opacity: 1, y: 0}}
+                      exit={{opacity: 0, y: 10}}
+                      className='absolute inset-x-0 bottom-0 bg-linear-to-t from-black/80 via-black/40 to-transparent p-6.5'>
+                      <p className='text-h3 font-bold text-white'>
+                        {project.title}
+                      </p>
+                    </motion.div>
                   )}
-
-                  <AnimatePresence>
-                    {isActive && (
-                      <motion.div
-                        initial={{opacity: 0, y: 20}}
-                        animate={{opacity: 1, y: 0}}
-                        exit={{opacity: 0, y: 10}}
-                        className='absolute inset-x-0 bottom-0 bg-linear-to-t from-black/80 via-black/40 to-transparent p-6.5'>
-                        <p className='text-h3 font-bold text-white'>
-                          {project.title}
-                        </p>
-                      </motion.div>
-                    )}
-                  </AnimatePresence>
-                </div>
+                </AnimatePresence>
               </div>
             </motion.div>
           );


### PR DESCRIPTION
## ISSUE 🔗
  
close #364
                                                                                                                   
                                                                     
  ## What is this PR? 🔍

  \`perspective-distant\` + \`transform-3d\` 3D 컨텍스트 안에서 CSS
  transform된 요소의 히트 영역이 시각적 영역과 불일치하는 브라우저
  특성으로, About Us 프로젝트 카드 캐러셀에서 옆 카드의 가운데 일부분만
   클릭 가능하던 문제를 수정합니다.

  - 모든 \`motion.div\`에 \`pointer-events: none\` 적용하여 3D 히트
  영역 문제 우회
  - 3D 컨텍스트 밖에 투명한 2D 클릭 존 버튼 2개(\`z-20\`)를 배치
    - 중앙 카드(436px) 기준 좌우 바깥 영역(\`calc(50% - 218px)\`)을
  각각 커버
    - 옆 카드 어느 부분을 눌러도 이전/다음 카드로 전환 가능

  <br><br>

  ## Screenshot 📷

  <!-- 구현된 기능/디자인 gif -->

  <br><br>

  ## Test Checklist ✔

  - [ ] About Us 섹션에서 오른쪽 옆 카드의 상단/중단/하단 어디를 눌러도
   다음 카드로 전환되는지 확인
  - [ ] 왼쪽 옆 카드의 상단/중단/하단 어디를 눌러도 이전 카드로
  전환되는지 확인
  - [ ] 첫 번째 카드에서 왼쪽 클릭 시 변화 없음 확인
  - [ ] 마지막 카드에서 오른쪽 클릭 시 변화 없음 확인
  - [ ] 3D 전환 애니메이션(spring)이 정상 동작하는지 확인