### PR TITLE
[PERF]: about-us 페이지 Swiper CSS render-blocking 제거

### DIFF
--- a/apps/homepage/src/app/(with-header)/(with-footer)/about-us/_containers/AboutUsMainActivitiesContainer.tsx
+++ b/apps/homepage/src/app/(with-header)/(with-footer)/about-us/_containers/AboutUsMainActivitiesContainer.tsx
@@ -2,17 +2,23 @@
 
 import Image from 'next/image';
 import {useEffect, useState} from 'react';
+import dynamic from 'next/dynamic';
 import AboutUsBackgroundSecond from '@/assets/about-us/background-about-us-second.webp';
 import {AboutUsDescription} from '@/app/(with-header)/(with-footer)/about-us/_components/AboutUsDescription';
 import {motion} from 'framer-motion';
-import 'swiper/css';
-import 'swiper/css/pagination';
 import {
   FADE_IN_UP_CONTAINER,
   FADE_IN_UP_ITEM,
 } from '@/constants/animation/motion-variants';
-import {AboutUsMobileMainActivitiesContainer} from '@/app/(with-header)/(with-footer)/about-us/_mobile/_containers/AboutUsMobileMainActivitiesContainer';
 import {AboutUsDesktopMainActivitiesContainer} from '@/app/(with-header)/(with-footer)/about-us/_desktop/_containers/AboutUsDesktopMainActivitiesContainer';
+
+const AboutUsMobileMainActivitiesContainer = dynamic(
+  () =>
+    import('@/app/(with-header)/(with-footer)/about-us/_mobile/_containers/AboutUsMobileMainActivitiesContainer').then(
+      (m) => m.AboutUsMobileMainActivitiesContainer
+    ),
+  {ssr: false}
+);
 
 export interface AboutUsActivity {
   id: number;


### PR DESCRIPTION
## ISSUE 🔗

close #380

<br><br>

## What is this PR? 🔍

`AboutUsMainActivitiesContainer`에서 `swiper/css`, `swiper/css/pagination`이 정적 import되어 render-blocking 리소스로 로딩되던 문제를 개선합니다.

**변경 내용**
- `AboutUsMainActivitiesContainer`의 중복 Swiper CSS import(`swiper/css`, `swiper/css/pagination`) 제거
- 모바일 전용 컴포넌트 `AboutUsMobileMainActivitiesContainer`를 `next/dynamic({ ssr: false })`으로 변경하여 Swiper와 그 CSS가 클라이언트 hydration 이후 비동기 로딩되도록 개선

**영향 범위**
- `about-us` 페이지: `38c1f1b7464655c7.css`(17.2kB/104kB), `6d9feb0c4f829a43.css`(1.3kB/3.5kB) render-blocking 제거
- `(home)` 페이지: 동일 레이아웃(`(with-header)/(with-footer)`) 공유로 인해 함께 포함되던 Swiper CSS도 제거됨

<br><br>

## Screenshot 📷

해당 없음 (성능 개선)

<br><br>

## Test Checklist ✔

- [ ] about-us 페이지에서 모바일 활동 소개 슬라이더가 정상 동작하는지 확인
- [ ] 홈(index) 페이지 Network 탭에서 Swiper CSS가 render-blocking으로 표시되지 않는지 확인
- [ ] about-us 페이지 Network 탭에서 Swiper CSS가 render-blocking으로 표시되지 않는지 확인