### PR TITLE
[FIX]: 핵심 가치 섹션 가로 스와이프 시 페이지 상하 스크롤 현상 수정

### DIFF
--- a/apps/homepage/src/app/(with-header)/(with-footer)/(home)/_components/HomeCoreValue.tsx
+++ b/apps/homepage/src/app/(with-header)/(with-footer)/(home)/_components/HomeCoreValue.tsx
@@ -61,7 +61,7 @@ export const HomeCoreValue = () => {
             ref={scrollRef}
             onScroll={handleScroll}
             variants={FADE_IN_UP_CONTAINER}
-            className='scrollbar-hide flex snap-x snap-mandatory flex-row gap-7.5 overflow-x-auto lg:justify-center lg:overflow-x-visible'
+            className='scrollbar-hide flex snap-x snap-mandatory flex-row gap-7.5 overflow-x-auto overscroll-x-contain lg:justify-center lg:overflow-x-visible'
             role='list'>
             {items.map((item, idx) => (
               <motion.li


### PR DESCRIPTION
## ISSUE 🔗

close #381

<br><br>

## What is this PR? 🔍

홈 페이지 핵심 가치(Core Value) 섹션의 가로 스와이프 슬라이더에서 슬라이드 끝에 도달했을 때 스크롤이 부모(페이지)로 전파되어 페이지가 위아래로 흔들리던 현상을 수정합니다.

**변경 내용**
- `HomeCoreValue` 가로 스크롤 컨테이너(`motion.ul`)에 `overscroll-x-contain` 추가
- `overscroll-behavior-x: contain`은 수평 스크롤이 경계에 닿았을 때 수직 스크롤 체이닝(scroll chaining)이 발생하지 않도록 차단

<br><br>

## Screenshot 📷

해당 없음

<br><br>

## Test Checklist ✔

- [ ] 모바일에서 핵심 가치 섹션 첫 번째 슬라이드 좌측으로 스와이프 시 페이지가 위아래로 흔들리지 않는지 확인
- [ ] 모바일에서 핵심 가치 섹션 마지막 슬라이드 우측으로 스와이프 시 페이지가 위아래로 흔들리지 않는지 확인
- [ ] 슬라이드 좌우 이동이 정상 동작하는지 확인