### PR TITLE
[CI]: 이슈·PR 제목 기반 type 라벨 자동화 workflow 추가

### DIFF
--- a/.claude/skills/issue.md
+++ b/.claude/skills/issue.md
@@ -13,23 +13,42 @@
 
 ## 이슈 타입
 
-| 타입       | 이슈 제목 prefix | GitHub 라벨 |
-| ---------- | ---------------- | ----------- |
-| `feat`     | `[FEAT]`         | ✨ Feature  |
-| `fix`      | `[FIX]`          | 🐛 Bug      |
-| `refactor` | `[REFACTOR]`     | ✨ Feature  |
-| `design`   | `[DESIGN]`       | ✨ Feature  |
-| `docs`     | `[DOCS]`         | ✨ Feature  |
-| `test`     | `[TEST]`         | ✨ Feature  |
-| `chore`    | `[CHORE]`        | ✨ Feature  |
-| `ci`       | `[CI]`           | ✨ Feature  |
-| `perf`     | `[PERF]`         | ✨ Feature  |
+> **⚠️ CRITICAL: 이슈 제목 prefix는 반드시 `[TYPE]:` 형태로 콜론(:)을 포함한다. `[TYPE]` 단독으로 쓰는 것은 금지.**
+
+| 타입       | 이슈 제목 prefix | 타입 라벨          |
+| ---------- | ---------------- | ------------------ |
+| `feat`     | `[FEAT]:`        | `✨ Feature`       |
+| `fix`      | `[FIX]:`         | `🐛 Bug`           |
+| `refactor` | `[REFACTOR]:`    | `💦 Refactor`      |
+| `design`   | `[DESIGN]:`      | `🎨 Style`         |
+| `style`    | `[STYLE]:`       | `🎨 Style`         |
+| `ui`       | `[UI]:`          | `📷 UI`            |
+| `docs`     | `[DOCS]:`        | `📄 Documentation` |
+| `test`     | `[TEST]:`        | `🌊 TEST`          |
+| `chore`    | `[CHORE]:`       | `🧹 CHORE`         |
+| `ci`       | `[CI]:`          | `😎 DevOps`        |
+| `perf`     | `[PERF]:`        | `💦 Refactor`      |
+| `security` | `[SECURITY]:`    | `🐛 Bug`           |
+
+## 라벨 자동화 구조
+
+> - **type 라벨**: `.github/workflows/type-labeler.yml` — 이슈/PR 제목의 `[TYPE]:` 패턴 감지 후 **자동** 부착
+> - **scope 라벨 (이슈)**: workflow로 처리되지 않으므로 `--label`로 직접 지정
+> - **scope 라벨 (PR)**: `.github/labeler.yml` 이 변경 파일 기반으로 **자동** 부착
+
+이슈 생성 시 `--label`은 scope 라벨만 지정한다. type 라벨은 workflow가 자동으로 붙여준다.
+
+| scope         | 스코프 라벨   |
+| ------------- | ------------- |
+| `homepage`    | `🥔 HOMEPAGE` |
+| `recruit`     | `🥔 RECRUIT`  |
+| `root` / `ui` | `🍟 COMMON`   |
 
 ---
 
 ## 이슈 본문 템플릿
 
-### Feature Request — feat / refactor / design / docs / test / chore / ci / perf
+### Feature Request — feat / refactor / design / style / ui / docs / test / chore / ci / perf
 
 ```markdown
 ### 🛠️ 만들고자 한 기능 설명
@@ -53,7 +72,7 @@
 ### 📸 피그마 스크린샷
 ```
 
-### Bug Report — fix
+### Bug Report — fix / security
 
 ```markdown
 ## 어떤 버그인가요?
@@ -117,8 +136,9 @@ chore/ui/15-storybook-config-update
 ## 이슈 생성 계획
 
 타입: feat
-제목: [FEAT] 사용자 로그인 구현
+제목: [FEAT]: 사용자 로그인 구현
 Assignee: @me
+라벨: ✨ Feature, 🥔 HOMEPAGE
 
 ### 이슈 본문 미리보기
 ---
@@ -133,15 +153,21 @@ Base 브랜치: develop
 
 ### Phase 2 — 이슈 생성
 
+> 제목은 반드시 `[TYPE]:` 형태로 콜론을 포함한다.
+
 ```bash
 gh issue create \
-  --title "[FEAT] 제목" \
+  --title "[FEAT]: 제목" \
   --body "$(cat <<'EOF'
 ...
 EOF
 )" \
-  --assignee "@me"
+  --assignee "@me" \
+  --label "🥔 HOMEPAGE"
 ```
+
+> type 라벨(`✨ Feature` 등)은 `type-labeler.yml` workflow가 자동 부착하므로 생략.
+> scope 라벨(`🥔 HOMEPAGE` 등)은 이슈에 workflow가 없으므로 직접 지정.
 
 출력된 이슈 URL에서 번호 파싱.
 
@@ -174,5 +200,7 @@ git checkout -b {type}/{scope}/{번호}-{description} origin/develop
 ## 금지
 
 - 사용자 승인 없이 이슈를 생성하지 않는다
+- **`[TYPE]` 뒤에 콜론(:)을 빠뜨리지 않는다 — `[FEAT]`은 틀렸고 `[FEAT]:`이 맞다**
 - 브랜치 설명에 한국어를 그대로 쓰지 않는다 (반드시 영어 kebab-case 변환)
 - `gh` 인증 상태를 확인하지 않고 실행하지 않는다
+- `--label` 없이 이슈를 생성하지 않는다

--- a/.claude/skills/pr.md
+++ b/.claude/skills/pr.md
@@ -13,7 +13,7 @@
 ## 핵심 원칙
 
 1. **전체 커밋 히스토리 기준**: `develop` 브랜치에서 갈라진 전체 변경을 분석한다. 최신 커밋 하나만 보지 않는다.
-2. **제목은 [TYPE]: 한국어 요약** 형식 (예: `[FEAT]: 로그인 API 연동`)
+2. **제목은 `[TYPE]: 한국어 요약` 형식** — 콜론(:)은 필수다. (예: `[FEAT]: 로그인 API 연동`)
 3. **WHY 중심**: 무엇을 바꿨는지는 diff가 대신한다. 본문에는 왜 이 변경이 필요했는지를 적는다.
 4. **base 브랜치는 반드시 확인**: 기본값은 `develop`. 다르면 사용자에게 먼저 물어본다.
 
@@ -23,28 +23,73 @@
 
 1. `git log develop...HEAD --oneline`으로 포함될 커밋 전체 확인
 2. `git diff develop...HEAD --stat`으로 전체 변경 파악
-3. 브랜치 push 여부 확인 → 없으면 `git push -u origin <branch>` 수행
-4. PR 본문 초안 작성 (아래 템플릿 참고)
-5. draft PR로 열지 일반 PR로 열지 사용자에게 확인
-6. `gh pr create` 실행
+3. 브랜치 이름에서 `{type}`과 `{scope}` 추출 → 라벨 결정
+4. 브랜치 push 여부 확인 → 없으면 `git push -u origin <branch>` 수행
+5. PR 본문 초안 작성 (아래 템플릿 참고)
+6. draft PR로 열지 일반 PR로 열지 사용자에게 확인
+7. `gh pr create` 실행
 
 ---
 
 ## PR 제목 형식
 
+> **⚠️ CRITICAL: PR 제목은 반드시 `[TYPE]:` 형태로 콜론(:)을 포함한다. `[TYPE]` 단독으로 쓰는 것은 금지.**
+
 ```
 [TYPE]: <전체 변경사항을 아우르는 한국어 요약>
 ```
 
-| 커밋 타입  | TYPE       |
-| ---------- | ---------- |
-| `feat`     | `FEAT`     |
-| `fix`      | `FIX`      |
-| `design`   | `DESIGN`   |
-| `refactor` | `REFACTOR` |
-| `docs`     | `DOCS`     |
-| `test`     | `TEST`     |
-| `chore`    | `CHORE`    |
+| 커밋 타입  | TYPE          |
+| ---------- | ------------- |
+| `feat`     | `[FEAT]:`     |
+| `fix`      | `[FIX]:`      |
+| `design`   | `[DESIGN]:`   |
+| `style`    | `[STYLE]:`    |
+| `ui`       | `[UI]:`       |
+| `refactor` | `[REFACTOR]:` |
+| `docs`     | `[DOCS]:`     |
+| `test`     | `[TEST]:`     |
+| `chore`    | `[CHORE]:`    |
+| `ci`       | `[CI]:`       |
+| `perf`     | `[PERF]:`     |
+| `security` | `[SECURITY]:` |
+
+---
+
+## 라벨 자동 지정
+
+> **PR 라벨은 GitHub Actions workflow 두 개가 자동 처리한다. `--label`은 아래 기준으로만 추가한다.**
+>
+> - **type 라벨**: `.github/workflows/type-labeler.yml` — PR 제목의 `[TYPE]:` 패턴 감지 후 자동 부착
+> - **scope 라벨**: `.github/labeler.yml` — 변경된 파일 경로 기반 자동 부착
+>
+> 따라서 `gh pr create` 실행 시 `--label`을 별도로 지정하지 않아도 된다.
+> workflow가 실패하는 경우에만 아래 표를 참고해 수동으로 추가한다.
+
+### 타입 라벨 (참고용)
+
+| type       | 라벨               |
+| ---------- | ------------------ |
+| `feat`     | `✨ Feature`       |
+| `fix`      | `🐛 Bug`           |
+| `refactor` | `💦 Refactor`      |
+| `design`   | `🎨 Style`         |
+| `style`    | `🎨 Style`         |
+| `ui`       | `📷 UI`            |
+| `docs`     | `📄 Documentation` |
+| `test`     | `🌊 TEST`          |
+| `chore`    | `🧹 CHORE`         |
+| `ci`       | `😎 DevOps`        |
+| `perf`     | `💦 Refactor`      |
+| `security` | `🐛 Bug`           |
+
+### 스코프 라벨 (참고용)
+
+| scope         | 라벨          |
+| ------------- | ------------- |
+| `homepage`    | `🥔 HOMEPAGE` |
+| `recruit`     | `🥔 RECRUIT`  |
+| `root` / `ui` | `🍟 COMMON`   |
 
 ---
 
@@ -146,10 +191,14 @@ EOF
 )"
 ```
 
+> 라벨은 `type-labeler.yml` / `labeler.yml` workflow가 자동 처리하므로 `--label` 생략.
+
 ---
 
 ## 금지
 
 - PR을 merge하지 않는다 (사용자가 명시적으로 요청해도 확인 절차를 거친다)
 - force-push로 base 브랜치를 덮어쓰지 않는다
-- reviewer, label, milestone은 사용자가 명시한 경우에만 추가한다
+- **`[TYPE]` 뒤에 콜론(:)을 빠뜨리지 않는다 — `[FEAT]`은 틀렸고 `[FEAT]:`이 맞다**
+- `--label` 없이 PR을 생성하지 않는다
+- reviewer, milestone은 사용자가 명시한 경우에만 추가한다

--- a/.github/workflows/type-labeler.yml
+++ b/.github/workflows/type-labeler.yml
@@ -1,0 +1,62 @@
+name: "Type Labeler"
+
+on:
+  issues:
+    types: [opened, edited]
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const TYPE_LABEL_MAP = {
+              'FEAT':     '✨ Feature',
+              'FIX':      '🐛 Bug',
+              'REFACTOR': '💦 Refactor',
+              'PERF':     '💦 Refactor',
+              'DESIGN':   '🎨 Style',
+              'STYLE':    '🎨 Style',
+              'UI':       '📷 UI',
+              'DOCS':     '📄 Documentation',
+              'TEST':     '🌊 TEST',
+              'CHORE':    '🧹 CHORE',
+              'CI':       '😎 DevOps',
+              'SECURITY': '🐛 Bug',
+            };
+
+            const isPR = !!context.payload.pull_request;
+            const title = isPR
+              ? context.payload.pull_request.title
+              : context.payload.issue.title;
+            const number = isPR
+              ? context.payload.pull_request.number
+              : context.payload.issue.number;
+
+            const match = title.match(/^\[([A-Z]+)\]:/);
+            if (!match) {
+              console.log(`제목에서 [TYPE]: 패턴을 찾지 못했습니다: "${title}"`);
+              return;
+            }
+
+            const type = match[1];
+            const label = TYPE_LABEL_MAP[type];
+            if (!label) {
+              console.log(`알 수 없는 타입입니다: ${type}`);
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              labels: [label],
+            });
+
+            console.log(`라벨 "${label}" 을(를) #${number} 에 추가했습니다.`);

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -13,6 +13,7 @@ const Configuration = {
         'test',
         'revert',
         'chore',
+        'ci',
         'security',
         'ui',
         'comment',


### PR DESCRIPTION
## ISSUE 🔗

close #384

<br><br>

## What is this PR? 🔍

- **💡 배경**: 기존 `labeler.yml`은 변경 파일 경로 기반 scope 라벨만 처리하고 있어, 이슈와 PR 제목의 `[TYPE]:` 패턴에 따른 type 라벨은 자동화되지 않았습니다. GitHub UI에서 직접 생성하거나 팀원이 만든 이슈·PR에는 라벨이 전혀 붙지 않는 문제가 있었습니다.
- **✨ 주요 변경사항**: `type-labeler.yml` workflow를 추가하여 이슈·PR 제목에서 `[TYPE]:` 패턴을 파싱하고 대응하는 type 라벨을 자동으로 부착합니다. Claude 스킬 파일(`issue.md`, `pr.md`)도 workflow와 역할이 분리되도록 업데이트했습니다.
- **🧪 리뷰 포인트**: `type-labeler.yml`의 `TYPE_LABEL_MAP`이 레포 실제 라벨명과 일치하는지 확인 부탁드립니다.

**라벨 자동화 구조 (변경 후)**

| 대상 | type 라벨 | scope 라벨 |
|------|-----------|------------|
| 이슈 | `type-labeler.yml` (제목 파싱) | 직접 지정 |
| PR   | `type-labeler.yml` (제목 파싱) | `labeler.yml` (파일 경로) |

<br><br>

## Screenshot 📷

해당 없음

<br><br>

## Test Checklist ✔

- [ ] `[FEAT]:` 제목으로 이슈 생성 시 `✨ Feature` 라벨이 자동으로 붙는지 확인
- [ ] `[FIX]:` 제목으로 PR 생성 시 `🐛 Bug` 라벨이 자동으로 붙는지 확인
- [ ] `[TYPE]:` 패턴이 없는 제목에서는 라벨이 붙지 않고 workflow가 정상 종료되는지 확인