### PR TITLE
[CI]: 깃허브 이슈와 노션 칸반 자동 동기화 워크플로우 추가

### DIFF
--- a/.github/scripts/notion-issue-sync.js
+++ b/.github/scripts/notion-issue-sync.js
@@ -1,0 +1,92 @@
+'use strict';
+
+/**
+ * GitHub Issues ↔ Notion 칸반 동기화 스크립트
+ *
+ * 필요한 Notion DB 속성:
+ *   - 이름       (title)
+ *   - 상태       (select: "할 일" | "진행 중" | "완료")
+ *   - GitHub 링크 (url)
+ *   - 이슈 번호   (number)
+ *   - 레이블     (multi_select)
+ *   - 생성일     (date)
+ *   - 완료일     (date)
+ *   - 저장소     (rich_text)
+ */
+module.exports = async ({ github, context, core }) => {
+  const notionToken = process.env.NOTION_TOKEN;
+  const dbId = process.env.NOTION_DATABASE_ID;
+
+  if (!notionToken || !dbId) {
+    core.warning('NOTION_TOKEN 또는 NOTION_DATABASE_ID 시크릿이 설정되지 않았습니다.');
+    return;
+  }
+
+  const { owner, repo } = context.repo;
+  const issue = context.payload.issue;
+  const action = context.payload.action;
+
+  const notionFetch = async (path, method, body) => {
+    const res = await fetch(`https://api.notion.com/v1${path}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${notionToken}`,
+        'Content-Type': 'application/json',
+        'Notion-Version': '2022-06-28',
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Notion API ${res.status}: ${text}`);
+    }
+    return res.json();
+  };
+
+  const findPageByIssueUrl = async (url) => {
+    const result = await notionFetch(`/databases/${dbId}/query`, 'POST', {
+      filter: { property: 'GitHub 링크', url: { equals: url } },
+    });
+    return result.results?.[0] ?? null;
+  };
+
+  if (action === 'opened') {
+    const labels = (issue.labels ?? []).map((l) => ({ name: l.name }));
+
+    await notionFetch('/pages', 'POST', {
+      parent: { database_id: dbId },
+      properties: {
+        이름: { title: [{ text: { content: `#${issue.number} ${issue.title}` } }] },
+        상태: { select: { name: '할 일' } },
+        'GitHub 링크': { url: issue.html_url },
+        '이슈 번호': { number: issue.number },
+        레이블: { multi_select: labels },
+        생성일: { date: { start: issue.created_at } },
+        저장소: { rich_text: [{ text: { content: `${owner}/${repo}` } }] },
+      },
+    });
+    core.info(`Notion 페이지 생성: #${issue.number} — ${issue.title}`);
+    return;
+  }
+
+  const statusMap = { closed: '완료', reopened: '진행 중' };
+  const newStatus = statusMap[action];
+  if (!newStatus) {
+    core.info(`처리하지 않는 action: ${action}`);
+    return;
+  }
+
+  const page = await findPageByIssueUrl(issue.html_url);
+  if (!page) {
+    core.warning(`Notion에서 이슈 #${issue.number}를 찾을 수 없습니다. 먼저 이슈가 동기화되어야 합니다.`);
+    return;
+  }
+
+  const updateProps = { 상태: { select: { name: newStatus } } };
+  if (action === 'closed') {
+    updateProps['완료일'] = { date: { start: new Date().toISOString() } };
+  }
+
+  await notionFetch(`/pages/${page.id}`, 'PATCH', { properties: updateProps });
+  core.info(`Notion 페이지 업데이트: #${issue.number} → ${newStatus}`);
+};

--- a/.github/scripts/notion-setup.js
+++ b/.github/scripts/notion-setup.js
@@ -1,0 +1,141 @@
+'use strict';
+
+/**
+ * Notion DB 초기 설정 스크립트
+ * GitHub Actions workflow_dispatch로 실행 — 두 DB를 생성하고 ID를 이슈에 출력합니다.
+ */
+module.exports = async ({ github, context, core, parentPageId }) => {
+  const notionToken = process.env.NOTION_TOKEN;
+  if (!notionToken) {
+    core.setFailed('NOTION_TOKEN 시크릿이 설정되지 않았습니다. README를 참고하세요.');
+    return;
+  }
+
+  // Notion URL 또는 UUID 형식 모두 지원
+  const extractPageId = (input) => {
+    const cleaned = (input || '').trim().replace(/-/g, '');
+    const matches = [...cleaned.matchAll(/[a-f0-9]{32}/gi)];
+    return matches.length > 0 ? matches[matches.length - 1][0] : null;
+  };
+
+  const pageId = extractPageId(parentPageId);
+  if (!pageId) {
+    core.setFailed(
+      `유효하지 않은 부모 페이지 ID: "${parentPageId}"\n` +
+        'Notion 페이지 URL 전체 또는 32자리 UUID를 입력하세요.'
+    );
+    return;
+  }
+
+  const notionPost = async (path, body) => {
+    const res = await fetch(`https://api.notion.com/v1${path}`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${notionToken}`,
+        'Content-Type': 'application/json',
+        'Notion-Version': '2022-06-28',
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Notion API ${res.status}: ${text}`);
+    }
+    return res.json();
+  };
+
+  // ──────────────────────────────────────────────
+  // 1. 이슈 칸반 DB 생성
+  // ──────────────────────────────────────────────
+  core.info('이슈 칸반 DB 생성 중...');
+  const issuesDb = await notionPost('/databases', {
+    parent: {type: 'page_id', page_id: pageId},
+    is_inline: false,
+    title: [{text: {content: '📋 GitHub 이슈 칸반'}}],
+    properties: {
+      이름: {title: {}},
+      상태: {
+        select: {
+          options: [
+            {name: '할 일', color: 'gray'},
+            {name: '진행 중', color: 'blue'},
+            {name: '완료', color: 'green'},
+          ],
+        },
+      },
+      'GitHub 링크': {url: {}},
+      '이슈 번호': {number: {format: 'number'}},
+      레이블: {multi_select: {options: []}},
+      생성일: {date: {}},
+      완료일: {date: {}},
+      저장소: {rich_text: {}},
+    },
+  });
+
+  // ──────────────────────────────────────────────
+  // 2. 주간 리포트 DB 생성
+  // ──────────────────────────────────────────────
+  core.info('주간 리포트 DB 생성 중...');
+  const reportsDb = await notionPost('/databases', {
+    parent: {type: 'page_id', page_id: pageId},
+    is_inline: false,
+    title: [{text: {content: '📊 주간 협업 리포트'}}],
+    properties: {
+      이름: {title: {}},
+      'PR 오픈': {number: {format: 'number'}},
+      'PR 머지': {number: {format: 'number'}},
+      '새 이슈': {number: {format: 'number'}},
+      '해결 이슈': {number: {format: 'number'}},
+      '평균 머지 시간': {rich_text: {}},
+      'GitHub 링크': {url: {}},
+      '기간 시작': {date: {}},
+      '기간 종료': {date: {}},
+    },
+  });
+
+  const issuesDbId = issuesDb.id;
+  const reportsDbId = reportsDb.id;
+
+  core.info(`이슈 칸반 DB ID: ${issuesDbId}`);
+  core.info(`주간 리포트 DB ID: ${reportsDbId}`);
+
+  // ──────────────────────────────────────────────
+  // 3. GitHub Step Summary 출력
+  // ──────────────────────────────────────────────
+  const summaryBody = `## ✅ Notion DB 생성 완료
+
+두 데이터베이스가 지정한 Notion 페이지에 생성되었습니다.
+
+### 추가해야 할 GitHub 시크릿
+
+레포 **Settings → Secrets and variables → Actions → New repository secret**
+
+| 시크릿 이름 | 값 |
+|------------|-----|
+| \`NOTION_DATABASE_ID\` | \`${issuesDbId}\` |
+| \`NOTION_REPORTS_DATABASE_ID\` | \`${reportsDbId}\` |
+
+### 칸반 보드 뷰 활성화 방법
+
+1. Notion에서 **📋 GitHub 이슈 칸반** DB 열기
+2. 상단 **+ Add a view** 클릭
+3. **Board** 선택 → Group by **상태**
+
+> 시크릿 등록이 완료되면 이 이슈를 닫아주세요.`;
+
+  await core.summary.addRaw(summaryBody).write();
+
+  // ──────────────────────────────────────────────
+  // 4. GitHub 이슈로 ID 전달 (로그에만 남기지 않기 위해)
+  // ──────────────────────────────────────────────
+  const {owner, repo} = context.repo;
+  const {data: setupIssue} = await github.rest.issues.create({
+    owner,
+    repo,
+    title: '🛠️ [Setup] Notion DB 생성 완료 — 시크릿 등록 필요',
+    body: summaryBody,
+    labels: [],
+  });
+
+  core.info(`설정 이슈 생성 완료: ${setupIssue.html_url}`);
+};

--- a/.github/scripts/weekly-analytics.js
+++ b/.github/scripts/weekly-analytics.js
@@ -346,4 +346,49 @@ ${trafficSection}
   });
 
   core.info(`리포트 이슈 생성 완료: ${issue.html_url}`);
+
+  // ──────────────────────────────────────────────
+  // 8. Notion 리포트 페이지 생성
+  // ──────────────────────────────────────────────
+  const notionToken = process.env.NOTION_TOKEN;
+  const notionReportsDbId = process.env.NOTION_REPORTS_DATABASE_ID;
+
+  if (!notionToken || !notionReportsDbId) {
+    core.warning('NOTION_TOKEN 또는 NOTION_REPORTS_DATABASE_ID가 없어 Notion 동기화를 건너뜁니다.');
+    return;
+  }
+
+  await safe('notionReport', async () => {
+    const res = await fetch('https://api.notion.com/v1/pages', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${notionToken}`,
+        'Content-Type': 'application/json',
+        'Notion-Version': '2022-06-28',
+      },
+      body: JSON.stringify({
+        parent: {database_id: notionReportsDbId},
+        properties: {
+          이름: {
+            title: [{text: {content: `📊 주간 협업 리포트 — ${kst(now)}`}}],
+          },
+          'PR 오픈': {number: openedPRs.length},
+          'PR 머지': {number: mergedPRs.length},
+          '새 이슈': {number: newIssues.length},
+          '해결 이슈': {number: closedIssues.length},
+          '평균 머지 시간': {
+            rich_text: [
+              {text: {content: avgMergeMs > 0 ? formatMs(avgMergeMs) : '-'}},
+            ],
+          },
+          'GitHub 링크': {url: issue.html_url},
+          '기간 시작': {date: {start: weekAgo.toISOString()}},
+          '기간 종료': {date: {start: now.toISOString()}},
+        },
+      }),
+    });
+    if (!res.ok) throw new Error(`Notion API ${res.status}: ${await res.text()}`);
+    const page = await res.json();
+    core.info(`Notion 리포트 페이지 생성 완료: ${page.url}`);
+  });
 };

--- a/.github/workflows/notion-issue-sync.yml
+++ b/.github/workflows/notion-issue-sync.yml
@@ -1,0 +1,26 @@
+name: 📋 Notion 이슈 동기화
+
+on:
+  issues:
+    types: [opened, closed, reopened]
+
+permissions:
+  issues: read
+
+jobs:
+  sync:
+    name: Notion 동기화
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: GitHub 이슈 → Notion 칸반 동기화
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fn = require('./.github/scripts/notion-issue-sync.js')
+            await fn({ github, context, core })
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          NOTION_DATABASE_ID: ${{ secrets.NOTION_DATABASE_ID }}

--- a/.github/workflows/notion-setup.yml
+++ b/.github/workflows/notion-setup.yml
@@ -1,0 +1,47 @@
+name: 🛠️ Notion DB 초기 설정
+
+# 최초 1회만 수동 실행합니다.
+# 실행 전 NOTION_TOKEN 시크릿이 등록되어 있어야 합니다.
+#
+# [사전 준비]
+# 1. notion.so/my-integrations 에서 Integration 생성
+# 2. 생성된 Internal Integration Secret을 NOTION_TOKEN 시크릿으로 등록
+# 3. Notion에 새 페이지 생성 → ··· → Connections → 위 Integration 연결
+# 4. 페이지 URL에서 UUID 복사 (예: notion.so/My-Page-1a2b3c4d...)
+# 5. 아래 workflow_dispatch 에 UUID 입력하여 실행
+
+on:
+  workflow_dispatch:
+    inputs:
+      parent_page_id:
+        description: |
+          DB를 생성할 Notion 페이지 URL 또는 ID
+          예: https://www.notion.so/My-Page-1a2b3c4d5e6f... 또는 1a2b3c4d5e6f...
+        required: true
+        type: string
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  setup:
+    name: Notion 데이터베이스 생성
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Notion DB 생성 및 시크릿 안내 이슈 등록
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fn = require('./.github/scripts/notion-setup.js')
+            await fn({
+              github,
+              context,
+              core,
+              parentPageId: '${{ inputs.parent_page_id }}',
+            })
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}

--- a/.github/workflows/weekly-analytics.yml
+++ b/.github/workflows/weekly-analytics.yml
@@ -22,3 +22,6 @@ jobs:
           script: |
             const fn = require('./.github/scripts/weekly-analytics.js')
             await fn({ github, context, core })
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          NOTION_REPORTS_DATABASE_ID: ${{ secrets.NOTION_REPORTS_DATABASE_ID }}


### PR DESCRIPTION
## ISSUE 🔗

close #388

<br><br>

## What is this PR? 🔍

- **💡 배경**: 이슈 관리를 GitHub과 Notion에서 이중으로 수작업하는 번거로움을 없애기 위해 자동화 워크플로우를 추가했습니다.
- **✨ 주요 변경사항**:
  - `notion-issue-sync.yml` / `notion-issue-sync.js` — 이슈 opened/closed/reopened 이벤트 발생 시 Notion 칸반 DB 카드를 자동으로 생성·상태 변경합니다
  - `notion-setup.yml` / `notion-setup.js` — `workflow_dispatch`로 Notion DB 두 개(이슈 칸반, 주간 리포트)를 자동 생성하고 필요한 시크릿 ID를 GitHub 이슈로 전달합니다
  - `weekly-analytics.yml` / `weekly-analytics.js` — 기존 주간 협업 리포트를 GitHub 이슈뿐만 아니라 Notion 리포트 DB에도 함께 기록합니다
- **🧪 리뷰 포인트**: `NOTION_TOKEN`, `NOTION_DATABASE_ID`, `NOTION_REPORTS_DATABASE_ID` 시크릿 등록 후 동작 확인이 필요합니다. `notion-setup` 워크플로우를 먼저 실행하면 DB ID를 자동으로 안내받을 수 있습니다.

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->

<br><br>

## Test Checklist ✔

- [ ] `🛠️ Notion DB 초기 설정` 워크플로우 수동 실행 → DB 두 개 생성 확인
- [ ] 이슈 생성 시 Notion 칸반에 "할 일" 카드 자동 등록 확인
- [ ] 이슈 닫기 시 Notion 카드 상태 "완료" 변경 확인
- [ ] 주간 리포트 워크플로우 실행 시 Notion 리포트 DB에 페이지 생성 확인