### PR TITLE
[CI]: 풀리퀘스트 번들 사이즈 자동 분석 워크플로우 추가

### DIFF
--- a/.github/scripts/bundle-size-report.js
+++ b/.github/scripts/bundle-size-report.js
@@ -9,6 +9,9 @@ const fs = require('fs');
 const parseBuildOutput = (rawOutput) => {
   const output = rawOutput
     .split('\n')
+    // ANSI 이스케이프 코드 제거 (Next.js 컬러 출력 대응)
+    .map((line) => line.replace(/\[[0-9;]*m/g, ''))
+    // turbo run 접두사 제거 (예: "homepage:build: ")
     .map((line) => line.replace(/^[^\s]+:build:\s?/, ''))
     .join('\n');
 

--- a/.github/scripts/bundle-size-report.js
+++ b/.github/scripts/bundle-size-report.js
@@ -1,0 +1,150 @@
+'use strict';
+
+const fs = require('fs');
+
+/**
+ * Next.js 빌드 출력에서 라우트별 번들 크기를 파싱합니다.
+ * turbo run 출력 형식 (앱명:build: 접두사 포함/미포함 모두 처리)
+ */
+const parseBuildOutput = (rawOutput) => {
+  const output = rawOutput
+    .split('\n')
+    .map((line) => line.replace(/^[^\s]+:build:\s?/, ''))
+    .join('\n');
+
+  const routes = [];
+  // ┌ ○ /path    5.56 kB    93.2 kB 형식 매칭
+  const routeRegex =
+    /[┌├└│]\s+[○●λ◑ƒ]\s+(\/\S*)\s+([\d.]+\s*[kMGT]?B)\s+([\d.]+\s*[kMGT]?B)/g;
+
+  let match;
+  while ((match = routeRegex.exec(output)) !== null) {
+    routes.push({
+      path: match[1],
+      size: match[2].trim(),
+      firstLoad: match[3].trim(),
+    });
+  }
+
+  const sharedMatch = output.match(
+    /First Load JS shared by all\s+([\d.]+\s*[kMGT]?B)/
+  );
+
+  return { routes, sharedSize: sharedMatch?.[1]?.trim() ?? null };
+};
+
+/**
+ * First Load JS 크기 문자열을 kB 단위 숫자로 변환합니다.
+ */
+const toKb = (sizeStr) => {
+  const match = sizeStr.match(/([\d.]+)\s*([kMG]?B)/);
+  if (!match) return 0;
+  const value = parseFloat(match[1]);
+  const unit = match[2];
+  if (unit === 'MB') return value * 1024;
+  if (unit === 'kB') return value;
+  return value / 1024;
+};
+
+const WARN_THRESHOLD_KB = 200;
+const ERROR_THRESHOLD_KB = 350;
+
+const sizeIcon = (firstLoadStr) => {
+  const kb = toKb(firstLoadStr);
+  if (kb >= ERROR_THRESHOLD_KB) return '🔴';
+  if (kb >= WARN_THRESHOLD_KB) return '🟡';
+  return '🟢';
+};
+
+const formatRouteTable = (appLabel, { routes, sharedSize }) => {
+  if (!routes.length) {
+    return `### ${appLabel}\n\n> ⚠️ 빌드 출력을 파싱하지 못했습니다.\n`;
+  }
+
+  const rows = routes
+    .map(
+      (r) =>
+        `| \`${r.path}\` | ${r.size} | ${r.firstLoad} | ${sizeIcon(r.firstLoad)} |`
+    )
+    .join('\n');
+
+  const sharedLine = sharedSize ? `\n> 공유 번들: **${sharedSize}**\n` : '';
+
+  return `### ${appLabel}
+
+| 라우트 | 크기 | First Load JS | 상태 |
+|--------|------|---------------|------|
+${rows}
+${sharedLine}`;
+};
+
+module.exports = async ({ github, context, core }) => {
+  const prNumber = context.payload.pull_request?.number;
+  if (!prNumber) {
+    core.warning('PR 컨텍스트를 찾을 수 없습니다.');
+    return;
+  }
+
+  const { owner, repo } = context.repo;
+
+  const readBuild = (filePath) => {
+    try {
+      return fs.readFileSync(filePath, 'utf8');
+    } catch {
+      return '';
+    }
+  };
+
+  const homepageBuild = parseBuildOutput(readBuild('/tmp/homepage-build.txt'));
+  const recruitBuild = parseBuildOutput(readBuild('/tmp/recruit-build.txt'));
+
+  const hasAnyRoute =
+    homepageBuild.routes.length > 0 || recruitBuild.routes.length > 0;
+  if (!hasAnyRoute) {
+    core.warning('번들 크기 데이터를 파싱하지 못했습니다. 빌드 출력을 확인하세요.');
+    return;
+  }
+
+  const legend = `> 🟢 정상 (<${WARN_THRESHOLD_KB}kB)  🟡 주의 (<${ERROR_THRESHOLD_KB}kB)  🔴 초과 (≥${ERROR_THRESHOLD_KB}kB) — First Load JS 기준`;
+
+  const body = `## 📦 번들 사이즈 리포트
+
+${formatRouteTable('🏠 Homepage (cotato.kr)', homepageBuild)}
+
+${formatRouteTable('📝 Recruit (recruit.cotato.kr)', recruitBuild)}
+
+---
+
+${legend}
+
+*빌드 커밋: \`${context.sha.slice(0, 7)}\`*`;
+
+  // 기존 봇 코멘트 삭제 후 재게시
+  const { data: comments } = await github.rest.issues.listComments({
+    owner,
+    repo,
+    issue_number: prNumber,
+  });
+
+  for (const comment of comments) {
+    if (
+      comment.user?.type === 'Bot' &&
+      comment.body?.includes('번들 사이즈 리포트')
+    ) {
+      await github.rest.issues.deleteComment({
+        owner,
+        repo,
+        comment_id: comment.id,
+      });
+    }
+  }
+
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: prNumber,
+    body,
+  });
+
+  core.info('번들 사이즈 리포트 PR 코멘트 게시 완료');
+};

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -37,12 +37,20 @@ jobs:
           echo "NEXT_PUBLIC_S3_HOSTNAME=${{ secrets.HOMEPAGE_S3_HOSTNAME }}" >> apps/homepage/.env
 
       - name: Build homepage
-        run: pnpm turbo run build --filter=homepage 2>&1 | tee /tmp/homepage-build.txt
+        run: pnpm turbo run build --filter=homepage --log-output=full 2>&1 | tee /tmp/homepage-build.txt
         continue-on-error: true
 
       - name: Build recruit
-        run: pnpm turbo run build --filter=recruit 2>&1 | tee /tmp/recruit-build.txt
+        run: pnpm turbo run build --filter=recruit --log-output=full 2>&1 | tee /tmp/recruit-build.txt
         continue-on-error: true
+
+      - name: Debug - 빌드 출력 확인
+        if: always()
+        run: |
+          echo "=== homepage (마지막 40줄) ==="
+          tail -40 /tmp/homepage-build.txt 2>/dev/null || echo "(파일 없음)"
+          echo "=== recruit (마지막 40줄) ==="
+          tail -40 /tmp/recruit-build.txt 2>/dev/null || echo "(파일 없음)"
 
       - name: 번들 사이즈 PR 코멘트 게시
         uses: actions/github-script@v7

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,0 +1,53 @@
+name: 📦 번들 사이즈 리포트
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main, develop]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: bundle-size-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bundle-size:
+    name: Bundle Size Report
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Create env files
+        run: |
+          echo "NEXT_PUBLIC_API_BASE_URL=${{ secrets.RECRUIT_API_BASE_URL }}" > apps/recruit/.env
+          echo "NEXT_PUBLIC_API_BASE_URL=${{ secrets.HOMEPAGE_API_BASE_URL }}" > apps/homepage/.env
+          echo "NEXT_PUBLIC_S3_HOSTNAME=${{ secrets.HOMEPAGE_S3_HOSTNAME }}" >> apps/homepage/.env
+
+      - name: Build homepage
+        run: pnpm turbo run build --filter=homepage 2>&1 | tee /tmp/homepage-build.txt
+        continue-on-error: true
+
+      - name: Build recruit
+        run: pnpm turbo run build --filter=recruit 2>&1 | tee /tmp/recruit-build.txt
+        continue-on-error: true
+
+      - name: 번들 사이즈 PR 코멘트 게시
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fn = require('./.github/scripts/bundle-size-report.js')
+            await fn({ github, context, core })


### PR DESCRIPTION
## ISSUE 🔗

close #389

<br><br>

## What is this PR? 🔍

- **💡 배경**: PR마다 번들 크기 변화를 수동으로 확인하기 어려워 성능 회귀를 조기에 감지하기 위해 자동화 워크플로우를 추가했습니다.
- **✨ 주요 변경사항**:
  - `bundle-size.yml` — PR opened/synchronize 시 Homepage, Recruit 두 앱을 각각 빌드하고 분석을 실행합니다
  - `bundle-size-report.js` — Next.js 빌드 출력에서 라우트별 번들 크기를 파싱해 PR 코멘트로 자동 게시합니다. 커밋이 푸시될 때마다 기존 코멘트를 교체합니다
- **🧪 리뷰 포인트**: First Load JS 임계값 기준(200kB 🟡, 350kB 🔴)이 적절한지 확인 부탁드립니다.

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->

<br><br>

## Test Checklist ✔

- [ ] PR 생성 시 번들 사이즈 리포트 코멘트 자동 게시 확인
- [ ] 커밋 추가 시 기존 코멘트가 최신 결과로 교체되는 것 확인
- [ ] Homepage / Recruit 두 앱 모두 라우트 크기 표시 확인