### PR TITLE
[FIX]: 코커톤 일정 날짜 수정

### DIFF
--- a/apps/homepage/src/app/(with-header)/(with-footer)/(home)/_desktop/_components/HomeDesktopMainSchedule.tsx
+++ b/apps/homepage/src/app/(with-header)/(with-footer)/(home)/_desktop/_components/HomeDesktopMainSchedule.tsx
@@ -39,7 +39,7 @@ export const HomeDesktopMainSchedule = () => {
         <BlackRowKeycap
           imageSrc='/images/main-schedule/cokerthon.webp'
           title='코커톤'
-          subTitle='2026.07.24'
+          subTitle='2026.07.10'
         />
       </div>
       <div className='col-start-4 row-start-3'>

--- a/apps/homepage/src/app/(with-header)/(with-footer)/(home)/_mobile/_components/HomeMobileMainSchedule.tsx
+++ b/apps/homepage/src/app/(with-header)/(with-footer)/(home)/_mobile/_components/HomeMobileMainSchedule.tsx
@@ -20,7 +20,7 @@ export const HomeMobileMainSchedule = () => {
         <BlackRowKeycap
           imageSrc='/images/main-schedule/cokerthon.webp'
           title='코커톤'
-          subTitle='2026.07.24'
+          subTitle='2026.07.10'
         />
       </div>
 


### PR DESCRIPTION
## ISSUE 🔗

close #395

<br><br>

## What is this PR? 🔍

- **💡 배경**: 홈 메인 스케줄 섹션에 표시되는 코커톤 날짜가 `2026.07.24`로 잘못 표기되어 있었습니다.
- **✨ 주요 변경사항**: 데스크탑과 모바일 메인 스케줄 컴포넌트의 코커톤 날짜를 `2026.07.10`으로 수정했습니다.
- **🧪 리뷰 포인트**: 데스크탑/모바일 양쪽 컴포넌트 모두 동일하게 수정되었는지 확인 부탁드립니다.

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->

<br><br>

## Test Checklist ✔

- [ ] 데스크탑 홈 메인 스케줄 코커톤 날짜 `2026.07.10` 표시 확인
- [ ] 모바일 홈 메인 스케줄 코커톤 날짜 `2026.07.10` 표시 확인