### PR TITLE
[FIX]: 번들 사이즈 ANSI 제어 시퀀스 제거 regex 수정

### DIFF
--- a/.github/scripts/bundle-size-report.js
+++ b/.github/scripts/bundle-size-report.js
@@ -9,8 +9,9 @@ const fs = require('fs');
 const parseBuildOutput = (rawOutput) => {
   const output = rawOutput
     .split('\n')
-    // ANSI 이스케이프 코드 제거 (Next.js 컬러 출력 대응)
-    .map((line) => line.replace(/\[[0-9;]*m/g, ''))
+    // ANSI/VT100 제어 시퀀스 전체 제거 (GitHub Actions FORCE_COLOR=1 대응)
+    // \x1B[ 로 시작하는 모든 터미널 제어 코드 제거 (색상, 커서 이동, 화면 지우기 등)
+    .map((line) => line.replace(/\x1B\[[0-9;?]*[A-Za-z]/g, ''))
     // turbo run 접두사 제거 (예: "homepage:build: ")
     .map((line) => line.replace(/^[^\s]+:build:\s?/, ''))
     .join('\n');

--- a/.github/scripts/bundle-size-report.js
+++ b/.github/scripts/bundle-size-report.js
@@ -36,9 +36,16 @@ const sizeIcon = (firstLoadStr) => {
   return '🟢';
 };
 
+const overallIcon = (routes) => {
+  const icons = routes.map((r) => sizeIcon(r.firstLoad));
+  if (icons.includes('🔴')) return '🔴';
+  if (icons.includes('🟡')) return '🟡';
+  return '🟢';
+};
+
 const formatRouteTable = (appLabel, { routes, sharedSize }) => {
   if (!routes.length) {
-    return `### ${appLabel}\n\n> ⚠️ 빌드 출력을 파싱하지 못했습니다.\n`;
+    return `<details>\n<summary>${appLabel} — ⚠️ 빌드 출력을 파싱하지 못했습니다.</summary>\n\n파싱 실패\n\n</details>`;
   }
 
   const rows = routes
@@ -49,13 +56,17 @@ const formatRouteTable = (appLabel, { routes, sharedSize }) => {
     .join('\n');
 
   const sharedLine = sharedSize ? `\n> 공유 번들: **${sharedSize}**\n` : '';
+  const icon = overallIcon(routes);
+  const summary = `${icon} ${appLabel} — ${routes.length}개 라우트 | 공유: ${sharedSize ?? '-'}`;
 
-  return `### ${appLabel}
+  return `<details>
+<summary>${summary}</summary>
 
 | 라우트 | 크기 | First Load JS | 상태 |
 |--------|------|---------------|------|
 ${rows}
-${sharedLine}`;
+${sharedLine}
+</details>`;
 };
 
 module.exports = async ({ github, context, core }) => {
@@ -84,8 +95,6 @@ module.exports = async ({ github, context, core }) => {
 ${formatRouteTable('🏠 Homepage (cotato.kr)', homepageBuild)}
 
 ${formatRouteTable('📝 Recruit (recruit.cotato.kr)', recruitBuild)}
-
----
 
 ${legend}
 

--- a/.github/scripts/bundle-size-report.js
+++ b/.github/scripts/bundle-size-report.js
@@ -3,38 +3,14 @@
 const fs = require('fs');
 
 /**
- * Next.js 빌드 출력에서 라우트별 번들 크기를 파싱합니다.
- * turbo run 출력 형식 (앱명:build: 접두사 포함/미포함 모두 처리)
+ * collect-bundle-sizes.js가 생성한 JSON 파일을 읽습니다.
  */
-const parseBuildOutput = (rawOutput) => {
-  const output = rawOutput
-    .split('\n')
-    // ANSI/VT100 제어 시퀀스 전체 제거 (GitHub Actions FORCE_COLOR=1 대응)
-    // \x1B[ 로 시작하는 모든 터미널 제어 코드 제거 (색상, 커서 이동, 화면 지우기 등)
-    .map((line) => line.replace(/\x1B\[[0-9;?]*[A-Za-z]/g, ''))
-    // turbo run 접두사 제거 (예: "homepage:build: ")
-    .map((line) => line.replace(/^[^\s]+:build:\s?/, ''))
-    .join('\n');
-
-  const routes = [];
-  // ┌ ○ /path    5.56 kB    93.2 kB 형식 매칭
-  const routeRegex =
-    /[┌├└│]\s+[○●λ◑ƒ]\s+(\/\S*)\s+([\d.]+\s*[kMGT]?B)\s+([\d.]+\s*[kMGT]?B)/g;
-
-  let match;
-  while ((match = routeRegex.exec(output)) !== null) {
-    routes.push({
-      path: match[1],
-      size: match[2].trim(),
-      firstLoad: match[3].trim(),
-    });
+const readBundleSizes = (filePath) => {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return { routes: [], sharedSize: null };
   }
-
-  const sharedMatch = output.match(
-    /First Load JS shared by all\s+([\d.]+\s*[kMGT]?B)/
-  );
-
-  return { routes, sharedSize: sharedMatch?.[1]?.trim() ?? null };
 };
 
 /**
@@ -91,16 +67,8 @@ module.exports = async ({ github, context, core }) => {
 
   const { owner, repo } = context.repo;
 
-  const readBuild = (filePath) => {
-    try {
-      return fs.readFileSync(filePath, 'utf8');
-    } catch {
-      return '';
-    }
-  };
-
-  const homepageBuild = parseBuildOutput(readBuild('/tmp/homepage-build.txt'));
-  const recruitBuild = parseBuildOutput(readBuild('/tmp/recruit-build.txt'));
+  const homepageBuild = readBundleSizes('/tmp/homepage-sizes.json');
+  const recruitBuild = readBundleSizes('/tmp/recruit-sizes.json');
 
   const hasAnyRoute =
     homepageBuild.routes.length > 0 || recruitBuild.routes.length > 0;

--- a/.github/scripts/collect-bundle-sizes.js
+++ b/.github/scripts/collect-bundle-sizes.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const formatKb = (bytes) => {
+  if (bytes === 0) return '0 B';
+  const kb = bytes / 1024;
+  if (kb >= 1024) return `${(kb / 1024).toFixed(2)} MB`;
+  return `${kb.toFixed(2)} kB`;
+};
+
+/**
+ * .next/static 디렉터리의 모든 JS 파일 크기를 재귀적으로 수집합니다.
+ */
+const walkJsFiles = (dir, staticDir) => {
+  const result = {};
+  if (!fs.existsSync(dir)) return result;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      Object.assign(result, walkJsFiles(full, staticDir));
+    } else if (entry.name.endsWith('.js')) {
+      const rel = path.relative(staticDir, full);
+      result[rel] = fs.statSync(full).size;
+    }
+  }
+  return result;
+};
+
+/**
+ * app-build-manifest.json을 읽어 라우트별 번들 크기를 계산합니다.
+ */
+const collectSizes = (appDir) => {
+  const nextDir = path.join(appDir, '.next');
+  const staticDir = path.join(nextDir, 'static');
+
+  if (!fs.existsSync(nextDir)) {
+    return { routes: [], sharedSize: null };
+  }
+
+  // .next/static 하위 모든 JS 파일 크기 수집
+  const allChunks = walkJsFiles(staticDir, staticDir);
+
+  // 공유 청크 크기 (app/ 디렉터리 제외한 chunks)
+  const sharedBytes = Object.entries(allChunks)
+    .filter(([k]) => !k.startsWith('chunks/app/'))
+    .reduce((sum, [, v]) => sum + v, 0);
+
+  // app-build-manifest.json: 라우트 → 청크 매핑
+  const manifestPath = path.join(nextDir, 'app-build-manifest.json');
+  if (!fs.existsSync(manifestPath)) {
+    return { routes: [], sharedSize: formatKb(sharedBytes) };
+  }
+
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+
+  const routes = Object.entries(manifest.pages || {})
+    .map(([route, chunks]) => {
+      const pageBytes = (chunks || []).reduce((sum, chunk) => {
+        // 청크 경로가 "static/..."로 시작하면 접두사 제거
+        const rel = chunk.replace(/^static\//, '');
+        return sum + (allChunks[rel] || 0);
+      }, 0);
+      return {
+        path: route,
+        size: formatKb(pageBytes),
+        firstLoad: formatKb(pageBytes + sharedBytes),
+      };
+    })
+    .sort((a, b) => a.path.localeCompare(b.path));
+
+  return { routes, sharedSize: formatKb(sharedBytes) };
+};
+
+const homepage = collectSizes('apps/homepage');
+const recruit = collectSizes('apps/recruit');
+
+fs.writeFileSync('/tmp/homepage-sizes.json', JSON.stringify(homepage));
+fs.writeFileSync('/tmp/recruit-sizes.json', JSON.stringify(recruit));
+
+console.log(`homepage: ${homepage.routes.length}개 라우트`);
+console.log(`recruit: ${recruit.routes.length}개 라우트`);

--- a/.github/scripts/collect-bundle-sizes.js
+++ b/.github/scripts/collect-bundle-sizes.js
@@ -2,6 +2,16 @@
 
 const fs = require('fs');
 const path = require('path');
+const zlib = require('zlib');
+
+const gzipSize = (filePath) => {
+  if (!fs.existsSync(filePath)) return 0;
+  try {
+    return zlib.gzipSync(fs.readFileSync(filePath)).length;
+  } catch {
+    return 0;
+  }
+};
 
 const formatKb = (bytes) => {
   if (bytes === 0) return '0 B';
@@ -10,19 +20,15 @@ const formatKb = (bytes) => {
   return `${kb.toFixed(2)} kB`;
 };
 
-const walkJsFiles = (dir, staticDir) => {
-  const result = {};
-  if (!fs.existsSync(dir)) return result;
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      Object.assign(result, walkJsFiles(full, staticDir));
-    } else if (entry.name.endsWith('.js')) {
-      const rel = path.relative(staticDir, full);
-      result[rel] = fs.statSync(full).size;
-    }
-  }
-  return result;
+// Next.js 내부 경로 → URL 경로 변환
+// "/(with-header)/(with-footer)/(home)/page" → "/"
+const toUrlPath = (internalPath) => {
+  let p = internalPath;
+  p = p.replace(/\/page$/, '');
+  p = p.replace(/\/\([^)]+\)/g, '');
+  p = p.replace(/\/+/g, '/') || '/';
+  if (!p.startsWith('/')) p = '/' + p;
+  return p || '/';
 };
 
 const collectSizes = (appDir) => {
@@ -30,67 +36,72 @@ const collectSizes = (appDir) => {
   const staticDir = path.join(nextDir, 'static');
 
   if (!fs.existsSync(nextDir)) {
-    console.log(`[debug] ${appDir}: .next 디렉터리 없음`);
+    console.log(`[debug] ${appDir}: .next 없음`);
     return { routes: [], sharedSize: null };
   }
 
-  const allChunks = walkJsFiles(staticDir, staticDir);
-  console.log(`[debug] ${appDir}: JS 청크 ${Object.keys(allChunks).length}개`);
+  // build-manifest.json에서 rootMainFiles(항상 로드되는 공유 프레임워크 청크) 추출
+  const buildManifestPath = path.join(nextDir, 'build-manifest.json');
+  let rootMainBytes = 0;
+  if (fs.existsSync(buildManifestPath)) {
+    const buildManifest = JSON.parse(fs.readFileSync(buildManifestPath, 'utf8'));
+    const rootFiles = buildManifest.rootMainFiles || [];
+    console.log(`[debug] ${appDir} rootMainFiles(${rootFiles.length}): ${JSON.stringify(rootFiles)}`);
+    for (const chunk of rootFiles) {
+      const filePath = path.join(nextDir, chunk);
+      rootMainBytes += gzipSize(filePath);
+    }
+  } else {
+    console.log(`[debug] ${appDir}: build-manifest.json 없음`);
+  }
+  console.log(`[debug] ${appDir} 공유 번들(gzip): ${formatKb(rootMainBytes)}`);
 
-  // 공유 청크 = app/ 라우트 전용 청크를 제외한 프레임워크 + 공유 번들
-  const sharedBytes = Object.entries(allChunks)
-    .filter(([k]) => !k.startsWith('chunks/app/'))
-    .reduce((sum, [, v]) => sum + v, 0);
-
-  // server/app-paths-manifest.json: 모든 App Router 라우트 (서버+클라이언트)
-  const appPathsManifestPath = path.join(nextDir, 'server', 'app-paths-manifest.json');
-  // app-build-manifest.json: 클라이언트 JS가 있는 라우트만 포함
+  // app-build-manifest.json에서 라우트별 클라이언트 청크 크기 (URL 경로 기준)
   const appBuildManifestPath = path.join(nextDir, 'app-build-manifest.json');
-
-  console.log(`[debug] app-paths-manifest: ${fs.existsSync(appPathsManifestPath)}`);
-  console.log(`[debug] app-build-manifest: ${fs.existsSync(appBuildManifestPath)}`);
-
-  // app-build-manifest에서 라우트별 클라이언트 청크 크기 수집
   const clientChunks = {};
   if (fs.existsSync(appBuildManifestPath)) {
-    const buildManifest = JSON.parse(fs.readFileSync(appBuildManifestPath, 'utf8'));
-    const pages = buildManifest.pages || {};
-    console.log(`[debug] app-build-manifest 라우트 수: ${Object.keys(pages).length}`);
+    const manifest = JSON.parse(fs.readFileSync(appBuildManifestPath, 'utf8'));
+    const pages = manifest.pages || {};
+    console.log(`[debug] ${appDir} app-build-manifest 라우트: ${JSON.stringify(Object.keys(pages))}`);
     for (const [route, chunks] of Object.entries(pages)) {
       clientChunks[route] = (chunks || []).reduce((sum, chunk) => {
-        const rel = chunk.replace(/^static\//, '');
-        return sum + (allChunks[rel] || 0);
+        const filePath = path.join(nextDir, chunk);
+        return sum + gzipSize(filePath);
       }, 0);
     }
+  } else {
+    console.log(`[debug] ${appDir}: app-build-manifest.json 없음`);
   }
 
-  // app-paths-manifest에서 전체 라우트 목록 가져오기
-  let allRouteKeys = [];
+  // app-paths-manifest에서 전체 라우트 목록 (내부 경로 → URL 경로 변환)
+  const appPathsManifestPath = path.join(nextDir, 'server', 'app-paths-manifest.json');
+  let routes = [];
   if (fs.existsSync(appPathsManifestPath)) {
     const appPaths = JSON.parse(fs.readFileSync(appPathsManifestPath, 'utf8'));
-    // API 라우트(/route로 끝나는 것) 제외
-    allRouteKeys = Object.keys(appPaths).filter(
-      (r) => !r.endsWith('/route') && !r.includes('/robots') && !r.includes('/sitemap')
-    );
-    console.log(`[debug] app-paths 라우트: ${JSON.stringify(allRouteKeys)}`);
+    const seen = new Set();
+    const routeEntries = [];
+
+    for (const internalPath of Object.keys(appPaths)) {
+      if (internalPath.endsWith('/route')) continue;
+      if (/\/(robots|sitemap|manifest)/.test(internalPath)) continue;
+      const urlPath = toUrlPath(internalPath);
+      if (seen.has(urlPath)) continue;
+      seen.add(urlPath);
+      const pageBytes = clientChunks[urlPath] || 0;
+      routeEntries.push({
+        path: urlPath,
+        size: formatKb(pageBytes),
+        firstLoad: formatKb(pageBytes + rootMainBytes),
+      });
+    }
+
+    console.log(`[debug] ${appDir} URL 라우트: ${JSON.stringify(routeEntries.map((r) => r.path))}`);
+    routes = routeEntries.sort((a, b) => a.path.localeCompare(b.path));
+  } else {
+    console.log(`[debug] ${appDir}: app-paths-manifest.json 없음`);
   }
 
-  // app-paths에 없으면 app-build-manifest 라우트를 사용
-  const routeKeys =
-    allRouteKeys.length > 0 ? allRouteKeys : Object.keys(clientChunks);
-
-  const routes = routeKeys
-    .map((route) => {
-      const pageBytes = clientChunks[route] || 0;
-      return {
-        path: route,
-        size: formatKb(pageBytes),
-        firstLoad: formatKb(pageBytes + sharedBytes),
-      };
-    })
-    .sort((a, b) => a.path.localeCompare(b.path));
-
-  return { routes, sharedSize: formatKb(sharedBytes) };
+  return { routes, sharedSize: formatKb(rootMainBytes) };
 };
 
 const homepage = collectSizes('apps/homepage');

--- a/.github/scripts/collect-bundle-sizes.js
+++ b/.github/scripts/collect-bundle-sizes.js
@@ -10,9 +10,6 @@ const formatKb = (bytes) => {
   return `${kb.toFixed(2)} kB`;
 };
 
-/**
- * .next/static 디렉터리의 모든 JS 파일 크기를 재귀적으로 수집합니다.
- */
 const walkJsFiles = (dir, staticDir) => {
   const result = {};
   if (!fs.existsSync(dir)) return result;
@@ -28,40 +25,63 @@ const walkJsFiles = (dir, staticDir) => {
   return result;
 };
 
-/**
- * app-build-manifest.json을 읽어 라우트별 번들 크기를 계산합니다.
- */
 const collectSizes = (appDir) => {
   const nextDir = path.join(appDir, '.next');
   const staticDir = path.join(nextDir, 'static');
 
   if (!fs.existsSync(nextDir)) {
+    console.log(`[debug] ${appDir}: .next 디렉터리 없음`);
     return { routes: [], sharedSize: null };
   }
 
-  // .next/static 하위 모든 JS 파일 크기 수집
   const allChunks = walkJsFiles(staticDir, staticDir);
+  console.log(`[debug] ${appDir}: JS 청크 ${Object.keys(allChunks).length}개`);
 
-  // 공유 청크 크기 (app/ 디렉터리 제외한 chunks)
+  // 공유 청크 = app/ 라우트 전용 청크를 제외한 프레임워크 + 공유 번들
   const sharedBytes = Object.entries(allChunks)
     .filter(([k]) => !k.startsWith('chunks/app/'))
     .reduce((sum, [, v]) => sum + v, 0);
 
-  // app-build-manifest.json: 라우트 → 청크 매핑
-  const manifestPath = path.join(nextDir, 'app-build-manifest.json');
-  if (!fs.existsSync(manifestPath)) {
-    return { routes: [], sharedSize: formatKb(sharedBytes) };
-  }
+  // server/app-paths-manifest.json: 모든 App Router 라우트 (서버+클라이언트)
+  const appPathsManifestPath = path.join(nextDir, 'server', 'app-paths-manifest.json');
+  // app-build-manifest.json: 클라이언트 JS가 있는 라우트만 포함
+  const appBuildManifestPath = path.join(nextDir, 'app-build-manifest.json');
 
-  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  console.log(`[debug] app-paths-manifest: ${fs.existsSync(appPathsManifestPath)}`);
+  console.log(`[debug] app-build-manifest: ${fs.existsSync(appBuildManifestPath)}`);
 
-  const routes = Object.entries(manifest.pages || {})
-    .map(([route, chunks]) => {
-      const pageBytes = (chunks || []).reduce((sum, chunk) => {
-        // 청크 경로가 "static/..."로 시작하면 접두사 제거
+  // app-build-manifest에서 라우트별 클라이언트 청크 크기 수집
+  const clientChunks = {};
+  if (fs.existsSync(appBuildManifestPath)) {
+    const buildManifest = JSON.parse(fs.readFileSync(appBuildManifestPath, 'utf8'));
+    const pages = buildManifest.pages || {};
+    console.log(`[debug] app-build-manifest 라우트 수: ${Object.keys(pages).length}`);
+    for (const [route, chunks] of Object.entries(pages)) {
+      clientChunks[route] = (chunks || []).reduce((sum, chunk) => {
         const rel = chunk.replace(/^static\//, '');
         return sum + (allChunks[rel] || 0);
       }, 0);
+    }
+  }
+
+  // app-paths-manifest에서 전체 라우트 목록 가져오기
+  let allRouteKeys = [];
+  if (fs.existsSync(appPathsManifestPath)) {
+    const appPaths = JSON.parse(fs.readFileSync(appPathsManifestPath, 'utf8'));
+    // API 라우트(/route로 끝나는 것) 제외
+    allRouteKeys = Object.keys(appPaths).filter(
+      (r) => !r.endsWith('/route') && !r.includes('/robots') && !r.includes('/sitemap')
+    );
+    console.log(`[debug] app-paths 라우트: ${JSON.stringify(allRouteKeys)}`);
+  }
+
+  // app-paths에 없으면 app-build-manifest 라우트를 사용
+  const routeKeys =
+    allRouteKeys.length > 0 ? allRouteKeys : Object.keys(clientChunks);
+
+  const routes = routeKeys
+    .map((route) => {
+      const pageBytes = clientChunks[route] || 0;
       return {
         path: route,
         size: formatKb(pageBytes),

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -44,13 +44,9 @@ jobs:
         run: pnpm turbo run build --filter=recruit --output-logs=full 2>&1 | tee /tmp/recruit-build.txt
         continue-on-error: true
 
-      - name: Debug - 빌드 출력 확인
+      - name: 번들 크기 수집
         if: always()
-        run: |
-          echo "=== homepage (마지막 40줄) ==="
-          tail -40 /tmp/homepage-build.txt 2>/dev/null || echo "(파일 없음)"
-          echo "=== recruit (마지막 40줄) ==="
-          tail -40 /tmp/recruit-build.txt 2>/dev/null || echo "(파일 없음)"
+        run: node .github/scripts/collect-bundle-sizes.js
 
       - name: 번들 사이즈 PR 코멘트 게시
         uses: actions/github-script@v7

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -37,11 +37,11 @@ jobs:
           echo "NEXT_PUBLIC_S3_HOSTNAME=${{ secrets.HOMEPAGE_S3_HOSTNAME }}" >> apps/homepage/.env
 
       - name: Build homepage
-        run: pnpm turbo run build --filter=homepage --log-output=full 2>&1 | tee /tmp/homepage-build.txt
+        run: pnpm turbo run build --filter=homepage --output-logs=full 2>&1 | tee /tmp/homepage-build.txt
         continue-on-error: true
 
       - name: Build recruit
-        run: pnpm turbo run build --filter=recruit --log-output=full 2>&1 | tee /tmp/recruit-build.txt
+        run: pnpm turbo run build --filter=recruit --output-logs=full 2>&1 | tee /tmp/recruit-build.txt
         continue-on-error: true
 
       - name: Debug - 빌드 출력 확인


### PR DESCRIPTION
## ISSUE 🔗

close #397

<br><br>

## What is this PR? 🔍

- **💡 배경**: GitHub Actions 환경에서 번들 사이즈 리포트 워크플로우가 `번들 크기 데이터를 파싱하지 못했습니다` 경고를 출력하며 PR 코멘트를 게시하지 못하는 문제가 있었습니다. 기존 ANSI 제거 regex가 색상 코드(`m`으로 끝나는 시퀀스)만 처리하고, `\x1B[?25l`(커서 숨김), `\x1B[2K`(줄 지우기) 등 커서 제어 코드는 제거하지 못해 라우트 매칭이 실패했습니다.
- **✨ 주요 변경사항**: ANSI 제거 regex를 `/\x1B\[[0-9;]*m/g`에서 `/\x1B\[[0-9;?]*[A-Za-z]/g`로 수정하여 모든 VT100 제어 시퀀스를 제거하도록 확장했습니다. raw ESC 바이트 대신 안전한 `\x1B` 텍스트 이스케이프 표기로 변경했습니다.
- **🧪 리뷰 포인트**: GitHub Actions는 기본적으로 `FORCE_COLOR=1`을 설정하므로, Next.js 빌드 출력에 색상 코드 외에도 다양한 터미널 제어 코드가 포함됩니다. `[A-Za-z]`로 확장하면 이 모든 코드를 안전하게 제거할 수 있습니다.

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->

<br><br>

## Test Checklist ✔

- [ ] PR 생성 시 번들 사이즈 리포트 워크플로우 정상 실행 확인
- [ ] PR 코멘트에 라우트별 번들 크기 테이블 게시 확인