### PR TITLE
[CHORE]: 에이전트 스킬 구조를 .agents/skills 기반으로 재편 및 심링크 전환

### DIFF
--- a/.agents/skills/cotato-code-review/SKILL.md
+++ b/.agents/skills/cotato-code-review/SKILL.md
@@ -1,3 +1,12 @@
+---
+name: cotato-code-review
+description: COTATO 프로젝트 코드 리뷰 워크플로우. "코드 리뷰해줘", "review" 입력 시 사용. CRITICAL/HIGH/MEDIUM/LOW 심각도 분류, 프로젝트 컨벤션 준수 확인.
+license: MIT
+metadata:
+  author: cotato
+  version: '1.0.0'
+---
+
 # code-review 스킬
 
 ## 트리거

--- a/.agents/skills/cotato-commit/SKILL.md
+++ b/.agents/skills/cotato-commit/SKILL.md
@@ -1,3 +1,12 @@
+---
+name: cotato-commit
+description: COTATO 프로젝트 커밋 워크플로우. "커밋해줘", "commit", /commit 입력 시 사용. atomic 단위 커밋 분리, secret guard, 계획 승인 후 실행.
+license: MIT
+metadata:
+  author: cotato
+  version: '1.0.0'
+---
+
 # commit 스킬
 
 ## 트리거

--- a/.agents/skills/cotato-doc-writer/SKILL.md
+++ b/.agents/skills/cotato-doc-writer/SKILL.md
@@ -1,3 +1,12 @@
+---
+name: cotato-doc-writer
+description: COTATO 프로젝트 문서 작성 워크플로우. "문서 만들어줘", "README 써줘" 입력 시 사용. README/설계문서/ADR 구조, Why 중심 서술.
+license: MIT
+metadata:
+  author: cotato
+  version: '1.0.0'
+---
+
 # doc-writer 스킬
 
 ## 트리거

--- a/.agents/skills/cotato-issue/SKILL.md
+++ b/.agents/skills/cotato-issue/SKILL.md
@@ -1,3 +1,12 @@
+---
+name: cotato-issue
+description: COTATO 프로젝트 GitHub 이슈 생성 워크플로우. "이슈 만들어줘", /issue 입력 시 사용. [TYPE]: 제목 형식, 템플릿 준수, 브랜치 자동 생성.
+license: MIT
+metadata:
+  author: cotato
+  version: '1.0.0'
+---
+
 # issue 스킬
 
 ## 트리거
@@ -165,9 +174,6 @@ EOF
   --assignee "@me" \
   --label "🥔 HOMEPAGE"
 ```
-
-> type 라벨(`✨ Feature` 등)은 `type-labeler.yml` workflow가 자동 부착하므로 생략.
-> scope 라벨(`🥔 HOMEPAGE` 등)은 이슈에 workflow가 없으므로 직접 지정.
 
 출력된 이슈 URL에서 번호 파싱.
 

--- a/.agents/skills/cotato-pr/SKILL.md
+++ b/.agents/skills/cotato-pr/SKILL.md
@@ -1,3 +1,12 @@
+---
+name: cotato-pr
+description: COTATO 프로젝트 PR 생성 워크플로우. "PR 만들어줘", "pull request", /pr 입력 시 사용. [TYPE]: 제목 형식, PR 템플릿 준수, develop 기준.
+license: MIT
+metadata:
+  author: cotato
+  version: '1.0.0'
+---
+
 # pr 스킬
 
 ## 트리거
@@ -100,13 +109,11 @@
 ```markdown
 ## ISSUE 🔗
 
-close #<이슈번호> <!-- 이슈 번호가 확인되면 작성, 없으면 빈 칸 -->
+close #<이슈번호>
 
 <br><br>
 
 ## What is this PR? 🔍
-
-<!-- 커밋 수에 따라 아래 구조 적용 -->
 
 <br><br>
 
@@ -200,5 +207,4 @@ EOF
 - PR을 merge하지 않는다 (사용자가 명시적으로 요청해도 확인 절차를 거친다)
 - force-push로 base 브랜치를 덮어쓰지 않는다
 - **`[TYPE]` 뒤에 콜론(:)을 빠뜨리지 않는다 — `[FEAT]`은 틀렸고 `[FEAT]:`이 맞다**
-- `--label` 없이 PR을 생성하지 않는다
 - reviewer, milestone은 사용자가 명시한 경우에만 추가한다

--- a/.agents/skills/cotato-release/SKILL.md
+++ b/.agents/skills/cotato-release/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: cotato-release
+description: COTATO 프로젝트 릴리즈 자동화 워크플로우. "릴리즈해줘", "release PR", /release 입력 시 사용. develop→release/X.Y.Z→main, GitHub Release draft 자동 생성.
+license: MIT
+metadata:
+  author: cotato
+  version: '1.0.0'
+---
+
+# release 스킬
+
+## 트리거
+
+다음 요청이 오면 이 스킬을 사용한다:
+
+- "릴리즈해줘", "릴리즈 만들어줘", "릴리즈 올려줘"
+- "release 브랜치 만들어줘", "release PR 올려줘"
+- `/release`
+
+---
+
+## 핵심 원칙
+
+1. **버전 확인 먼저**: 사용자가 버전을 명시하지 않으면 최신 태그를 확인하고 다음 버전을 제안한다.
+2. **develop → release/X.Y.Z → main 흐름**: release 브랜치는 항상 `develop` 기준으로 생성한다.
+3. **GitHub Release draft 먼저**: `gh release create --draft --generate-notes`로 자동 생성된 What's Changed를 가져온다.
+4. **PR 본문 = Release 노트**: 자동 생성된 내용을 그대로 PR 본문으로 사용한다. 수정하지 않는다.
+5. **PR은 draft로 생성하지 않는다**: release PR은 바로 Open 상태로 연다.
+
+---
+
+## 워크플로우
+
+### Step 1 — 버전 결정
+
+```bash
+gh release list --limit 1
+```
+
+버전이 명시되지 않은 경우: 최신 태그를 보여주고 다음 버전 (patch +1) 을 제안한다.
+사용자 확인 후 진행한다.
+
+### Step 2 — release 브랜치 생성 및 push
+
+```bash
+git checkout develop
+git pull origin develop
+git checkout -b release/X.Y.Z
+git push -u origin release/X.Y.Z
+```
+
+### Step 3 — GitHub Release draft 생성 (자동 노트 포함)
+
+```bash
+gh release create vX.Y.Z \
+  --draft \
+  --generate-notes \
+  --title "vX.Y.Z" \
+  --target release/X.Y.Z
+```
+
+### Step 4 — 자동 생성된 Release 노트 추출
+
+```bash
+RELEASE_NOTES=$(gh release view vX.Y.Z --json body --jq '.body')
+```
+
+### Step 5 — release PR 생성
+
+```bash
+gh pr create \
+  --title "[RELEASE]: vX.Y.Z" \
+  --body "$RELEASE_NOTES" \
+  --base main \
+  --head release/X.Y.Z
+```
+
+---
+
+## 실제 실행 스크립트
+
+```bash
+VERSION="X.Y.Z"
+
+git checkout develop && git pull origin develop
+git checkout -b release/$VERSION
+git push -u origin release/$VERSION
+
+gh release create v$VERSION \
+  --draft \
+  --generate-notes \
+  --title "v$VERSION" \
+  --target release/$VERSION
+
+NOTES=$(gh release view v$VERSION --json body --jq '.body')
+
+gh pr create \
+  --title "[RELEASE]: v$VERSION" \
+  --body "$NOTES" \
+  --base main \
+  --head release/$VERSION
+```
+
+---
+
+## 결과 출력
+
+```
+✅ 릴리즈 준비 완료
+
+- 브랜치: release/X.Y.Z
+- GitHub Release (draft): https://github.com/IT-Cotato/COTATO-FE-v2/releases/tag/vX.Y.Z
+- PR: <URL>
+
+다음 단계:
+1. PR 리뷰 후 main에 머지
+2. GitHub Release draft를 publish (Releases 탭에서 직접)
+```
+
+---
+
+## 주의사항
+
+- **Release publish는 자동으로 하지 않는다**: draft 상태로만 생성. PR 머지 후 사람이 직접 publish한다.
+- **버전 태그는 `v` 접두사 포함**: `1.0.2`로 입력해도 내부에서 `v`를 붙인다.
+- `--generate-notes`는 직전 태그 이후 `main`에 머지된 PR 기준으로 수집한다.
+- 이미 같은 태그가 존재하면 `gh release delete vX.Y.Z` 후 재시도한다.
+
+---
+
+## 금지
+
+- release 브랜치를 `main` 또는 `develop` 외 브랜치에서 파지 않는다
+- PR을 merge하지 않는다
+- Release를 publish(공개)하지 않는다 — draft 상태 유지
+- What's Changed 내용을 임의로 편집하거나 요약하지 않는다

--- a/.agents/skills/cotato-storybook/SKILL.md
+++ b/.agents/skills/cotato-storybook/SKILL.md
@@ -1,3 +1,12 @@
+---
+name: cotato-storybook
+description: COTATO UI 패키지 Storybook 스토리 작성 워크플로우. "스토리 만들어줘", "스토리북", /storybook 입력 시 사용. CSF3 패턴, packages/ui 구조 준수.
+license: MIT
+metadata:
+  author: cotato
+  version: '1.0.0'
+---
+
 # storybook 스킬
 
 ## 트리거

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,4 +1,0 @@
-{
-  "spinnerTipsEnabled": true,
-  "prefersReducedMotion": true
-}

--- a/.claude/skills/cotato-code-review
+++ b/.claude/skills/cotato-code-review
@@ -1,0 +1,1 @@
+C:/Users/user/Desktop/cotato-fe-v2/COTATO-FE-v2/.agents/skills/cotato-code-review

--- a/.claude/skills/cotato-commit
+++ b/.claude/skills/cotato-commit
@@ -1,0 +1,1 @@
+C:/Users/user/Desktop/cotato-fe-v2/COTATO-FE-v2/.agents/skills/cotato-commit

--- a/.claude/skills/cotato-doc-writer
+++ b/.claude/skills/cotato-doc-writer
@@ -1,0 +1,1 @@
+C:/Users/user/Desktop/cotato-fe-v2/COTATO-FE-v2/.agents/skills/cotato-doc-writer

--- a/.claude/skills/cotato-issue
+++ b/.claude/skills/cotato-issue
@@ -1,0 +1,1 @@
+C:/Users/user/Desktop/cotato-fe-v2/COTATO-FE-v2/.agents/skills/cotato-issue

--- a/.claude/skills/cotato-pr
+++ b/.claude/skills/cotato-pr
@@ -1,0 +1,1 @@
+C:/Users/user/Desktop/cotato-fe-v2/COTATO-FE-v2/.agents/skills/cotato-pr

--- a/.claude/skills/cotato-release
+++ b/.claude/skills/cotato-release
@@ -1,0 +1,1 @@
+C:/Users/user/Desktop/cotato-fe-v2/COTATO-FE-v2/.agents/skills/cotato-release

--- a/.claude/skills/cotato-storybook
+++ b/.claude/skills/cotato-storybook
@@ -1,0 +1,1 @@
+C:/Users/user/Desktop/cotato-fe-v2/COTATO-FE-v2/.agents/skills/cotato-storybook

--- a/.cursor/skills/cotato-code-review
+++ b/.cursor/skills/cotato-code-review
@@ -1,0 +1,1 @@
+C:/Users/user/Desktop/cotato-fe-v2/COTATO-FE-v2/.agents/skills/cotato-code-review

--- a/.cursor/skills/cotato-commit
+++ b/.cursor/skills/cotato-commit
@@ -1,0 +1,1 @@
+C:/Users/user/Desktop/cotato-fe-v2/COTATO-FE-v2/.agents/skills/cotato-commit

--- a/.cursor/skills/cotato-doc-writer
+++ b/.cursor/skills/cotato-doc-writer
@@ -1,0 +1,1 @@
+C:/Users/user/Desktop/cotato-fe-v2/COTATO-FE-v2/.agents/skills/cotato-doc-writer

--- a/.cursor/skills/cotato-issue
+++ b/.cursor/skills/cotato-issue
@@ -1,0 +1,1 @@
+C:/Users/user/Desktop/cotato-fe-v2/COTATO-FE-v2/.agents/skills/cotato-issue

--- a/.cursor/skills/cotato-pr
+++ b/.cursor/skills/cotato-pr
@@ -1,0 +1,1 @@
+C:/Users/user/Desktop/cotato-fe-v2/COTATO-FE-v2/.agents/skills/cotato-pr

--- a/.cursor/skills/cotato-release
+++ b/.cursor/skills/cotato-release
@@ -1,0 +1,1 @@
+C:/Users/user/Desktop/cotato-fe-v2/COTATO-FE-v2/.agents/skills/cotato-release

--- a/.cursor/skills/cotato-storybook
+++ b/.cursor/skills/cotato-storybook
@@ -1,0 +1,1 @@
+C:/Users/user/Desktop/cotato-fe-v2/COTATO-FE-v2/.agents/skills/cotato-storybook

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ yarn-error.log*
 # Misc
 .DS_Store
 *.pem
+
+# Claude Code local settings
+.claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,14 +108,23 @@ Import from `@repo/ui`. Key exports: `Button`, `FullButton`, `FormInput`, `FormT
 
 ## Skills
 
-이 프로젝트의 스킬은 `.claude/skills/` 에 정의되어 있습니다.
+스킬은 `.agents/skills/` 에 canonical 형태로 정의되어 있습니다.
 트리거가 발생하면 해당 파일을 읽고 그 지시를 따릅니다.
 
-| 트리거                                      | 스킬 파일                       |
-| ------------------------------------------- | ------------------------------- |
-| "커밋해줘", "commit", `/commit`             | `.claude/skills/commit.md`      |
-| "PR 만들어줘", "pull request", `/pr`        | `.claude/skills/pr.md`          |
-| "이슈 만들어줘", `/issue`                   | `.claude/skills/issue.md`       |
-| "코드 리뷰해줘", "review"                   | `.claude/skills/code-review.md` |
-| "스토리 만들어줘", "스토리북", `/storybook` | `.claude/skills/storybook.md`   |
-| "문서 만들어줘", "README"                   | `.claude/skills/doc-writer.md`  |
+**도구별 스킬 위치:**
+
+| 도구         | 위치                                             |
+| ------------ | ------------------------------------------------ |
+| Claude Code  | `.claude/skills/cotato-{name}/SKILL.md` (심링크) |
+| Cursor       | `.cursor/skills/cotato-{name}/SKILL.md` (심링크) |
+| Codex / 기타 | `.agents/skills/cotato-{name}/SKILL.md` (원본)   |
+
+| 트리거                                      | 스킬 이름            | canonical 경로                               |
+| ------------------------------------------- | -------------------- | -------------------------------------------- |
+| "커밋해줘", "commit", `/commit`             | `cotato-commit`      | `.agents/skills/cotato-commit/SKILL.md`      |
+| "PR 만들어줘", "pull request", `/pr`        | `cotato-pr`          | `.agents/skills/cotato-pr/SKILL.md`          |
+| "이슈 만들어줘", `/issue`                   | `cotato-issue`       | `.agents/skills/cotato-issue/SKILL.md`       |
+| "코드 리뷰해줘", "review"                   | `cotato-code-review` | `.agents/skills/cotato-code-review/SKILL.md` |
+| "스토리 만들어줘", "스토리북", `/storybook` | `cotato-storybook`   | `.agents/skills/cotato-storybook/SKILL.md`   |
+| "문서 만들어줘", "README"                   | `cotato-doc-writer`  | `.agents/skills/cotato-doc-writer/SKILL.md`  |
+| "릴리즈해줘", "release PR", `/release`      | `cotato-release`     | `.agents/skills/cotato-release/SKILL.md`     |


### PR DESCRIPTION
## ISSUE 🔗

close #400

<br><br>

## What is this PR? 🔍

- **💡 배경**: Claude Code, Cursor, Codex 등 여러 AI 도구가 프로젝트 스킬을 공유하려면 단일 소스가 필요했습니다. 기존 `.claude/skills/`의 플랫 파일 구조는 도구마다 파일을 따로 관리해야 해서 동기화 문제가 생길 수 있었습니다.
- **✨ 주요 변경사항**: `.agents/skills/cotato-{name}/SKILL.md`를 canonical 소스로 두고, `.claude/skills/`와 `.cursor/skills/`에 심링크를 생성했습니다. 스킬 내용을 한 곳에서만 수정하면 모든 도구에 자동으로 반영됩니다. 또한 릴리즈 자동화를 위한 `cotato-release` 스킬을 새로 추가했습니다.
- **🧪 리뷰 포인트**: 심링크(`120000` 모드)가 git에 정상 등록됐는지 확인 부탁드립니다.

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->

<br><br>

## Test Checklist ✔

- [ ] `.claude/skills/cotato-{name}` 심링크가 `.agents/skills/cotato-{name}/SKILL.md`를 올바르게 가리키는지 확인
- [ ] `.cursor/skills/cotato-{name}` 심링크 동일 확인
- [ ] `cotato-release` 스킬 트리거("릴리즈해줘") 동작 확인