### PR TITLE
[FIX]: 심링크 타겟을 절대 경로에서 상대 경로로 수정

### DIFF
--- a/.claude/skills/cotato-code-review
+++ b/.claude/skills/cotato-code-review
@@ -1,1 +1,1 @@
-C:/Users/user/Desktop/cotato-fe-v2/COTATO-FE-v2/.agents/skills/cotato-code-review
+../../.agents/skills/cotato-code-review

--- a/.claude/skills/cotato-commit
+++ b/.claude/skills/cotato-commit
@@ -1,1 +1,1 @@
-C:/Users/user/Desktop/cotato-fe-v2/COTATO-FE-v2/.agents/skills/cotato-commit
+../../.agents/skills/cotato-commit

--- a/.claude/skills/cotato-doc-writer
+++ b/.claude/skills/cotato-doc-writer
@@ -1,1 +1,1 @@
-C:/Users/user/Desktop/cotato-fe-v2/COTATO-FE-v2/.agents/skills/cotato-doc-writer
+../../.agents/skills/cotato-doc-writer

--- a/.claude/skills/cotato-issue
+++ b/.claude/skills/cotato-issue
@@ -1,1 +1,1 @@
-C:/Users/user/Desktop/cotato-fe-v2/COTATO-FE-v2/.agents/skills/cotato-issue
+../../.agents/skills/cotato-issue

--- a/.claude/skills/cotato-pr
+++ b/.claude/skills/cotato-pr
@@ -1,1 +1,1 @@
-C:/Users/user/Desktop/cotato-fe-v2/COTATO-FE-v2/.agents/skills/cotato-pr
+../../.agents/skills/cotato-pr

--- a/.claude/skills/cotato-release
+++ b/.claude/skills/cotato-release
@@ -1,1 +1,1 @@
-C:/Users/user/Desktop/cotato-fe-v2/COTATO-FE-v2/.agents/skills/cotato-release
+../../.agents/skills/cotato-release

--- a/.claude/skills/cotato-storybook
+++ b/.claude/skills/cotato-storybook
@@ -1,1 +1,1 @@
-C:/Users/user/Desktop/cotato-fe-v2/COTATO-FE-v2/.agents/skills/cotato-storybook
+../../.agents/skills/cotato-storybook

--- a/.cursor/skills/cotato-code-review
+++ b/.cursor/skills/cotato-code-review
@@ -1,1 +1,1 @@
-C:/Users/user/Desktop/cotato-fe-v2/COTATO-FE-v2/.agents/skills/cotato-code-review
+../../.agents/skills/cotato-code-review

--- a/.cursor/skills/cotato-commit
+++ b/.cursor/skills/cotato-commit
@@ -1,1 +1,1 @@
-C:/Users/user/Desktop/cotato-fe-v2/COTATO-FE-v2/.agents/skills/cotato-commit
+../../.agents/skills/cotato-commit

--- a/.cursor/skills/cotato-doc-writer
+++ b/.cursor/skills/cotato-doc-writer
@@ -1,1 +1,1 @@
-C:/Users/user/Desktop/cotato-fe-v2/COTATO-FE-v2/.agents/skills/cotato-doc-writer
+../../.agents/skills/cotato-doc-writer

--- a/.cursor/skills/cotato-issue
+++ b/.cursor/skills/cotato-issue
@@ -1,1 +1,1 @@
-C:/Users/user/Desktop/cotato-fe-v2/COTATO-FE-v2/.agents/skills/cotato-issue
+../../.agents/skills/cotato-issue

--- a/.cursor/skills/cotato-pr
+++ b/.cursor/skills/cotato-pr
@@ -1,1 +1,1 @@
-C:/Users/user/Desktop/cotato-fe-v2/COTATO-FE-v2/.agents/skills/cotato-pr
+../../.agents/skills/cotato-pr

--- a/.cursor/skills/cotato-release
+++ b/.cursor/skills/cotato-release
@@ -1,1 +1,1 @@
-C:/Users/user/Desktop/cotato-fe-v2/COTATO-FE-v2/.agents/skills/cotato-release
+../../.agents/skills/cotato-release

--- a/.cursor/skills/cotato-storybook
+++ b/.cursor/skills/cotato-storybook
@@ -1,1 +1,1 @@
-C:/Users/user/Desktop/cotato-fe-v2/COTATO-FE-v2/.agents/skills/cotato-storybook
+../../.agents/skills/cotato-storybook


### PR DESCRIPTION
## ISSUE 🔗

close #402

<br><br>

## What is this PR? 🔍

- **💡 배경**: PR #401에서 Windows `New-Item -ItemType SymbolicLink`로 심링크를 생성할 때 상대 경로(`../../.agents/skills/cotato-pr`)가 절대 경로(`C:/Users/.../cotato-pr`)로 변환되어 git에 저장되었습니다. 다른 환경에서 클론 시 심링크가 깨지는 문제가 발생합니다.
- **✨ 주요 변경사항**: `git hash-object`와 `git update-index`로 심링크 blob을 직접 작성해 `../../.agents/skills/{name}` 상대 경로가 그대로 git에 저장되도록 수정했습니다.
- **🧪 리뷰 포인트**: `git cat-file blob HEAD:.claude/skills/cotato-pr` 실행 시 `../../.agents/skills/cotato-pr`가 출력되는지 확인해 주세요.

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->

<br><br>

## Test Checklist ✔

- [ ] `git cat-file blob HEAD:.claude/skills/cotato-pr` → `../../.agents/skills/cotato-pr` 출력 확인
- [ ] `git cat-file blob HEAD:.cursor/skills/cotato-pr` → 동일 확인
- [ ] macOS/Linux 환경에서 클론 후 심링크 정상 작동 확인