### PR TITLE
[FEAT]: react-datepicker Dynamic Import 번들 분리

### DIFF
--- a/apps/homepage/src/app/(with-header)/(with-footer)/project/add-project/_components/AddProjectForm.tsx
+++ b/apps/homepage/src/app/(with-header)/(with-footer)/project/add-project/_components/AddProjectForm.tsx
@@ -4,7 +4,15 @@ import {useRouter} from 'next/navigation';
 import {ROUTES} from '@/constants/routes';
 import {FormInput} from '@repo/ui/components/form/FormInput';
 import {FormLink} from '@repo/ui/components/form/FormLink';
-import {PeriodField} from '@/app/(with-header)/(with-footer)/project/add-project/_components/PeriodField';
+import dynamic from 'next/dynamic';
+
+const PeriodField = dynamic(
+  () =>
+    import(
+      '@/app/(with-header)/(with-footer)/project/add-project/_components/PeriodField'
+    ).then((m) => m.PeriodField),
+  {ssr: false}
+);
 import {TeamSection} from '@/app/(with-header)/(with-footer)/project/add-project/_components/TeamSection';
 import {useTeamMembers} from '@/app/(with-header)/(with-footer)/project/add-project/_hooks/useTeamMember';
 import {FormField} from '@/app/(with-header)/(with-footer)/project/add-project/_components/FormField';

--- a/apps/homepage/src/app/(with-header)/(with-footer)/project/add-project/_components/PeriodField.tsx
+++ b/apps/homepage/src/app/(with-header)/(with-footer)/project/add-project/_components/PeriodField.tsx
@@ -57,6 +57,7 @@ export const PeriodField = ({
           formatWeekDay={(nameOfDay) => nameOfDay.toLowerCase().slice(0, 3)}
           renderCustomHeader={(props) => <CustomHeader {...props} />}
           disabledKeyboardNavigation
+          portalId='datepicker-portal'
         />
       </div>
       <div
@@ -79,6 +80,7 @@ export const PeriodField = ({
           formatWeekDay={(nameOfDay) => nameOfDay.toLowerCase().slice(0, 3)}
           renderCustomHeader={(props) => <CustomHeader {...props} />}
           disabledKeyboardNavigation
+          portalId='datepicker-portal'
         />
       </div>
     </div>

--- a/apps/homepage/src/app/(with-header)/(with-footer)/project/add-project/_components/PeriodField.tsx
+++ b/apps/homepage/src/app/(with-header)/(with-footer)/project/add-project/_components/PeriodField.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {useState, useEffect} from 'react';
 import {CustomHeader} from '@/app/(with-header)/(with-footer)/project/add-project/_components/calendar/CustomHeader';
 import {CustomInput} from '@/app/(with-header)/(with-footer)/project/add-project/_components/calendar/CustomInput';
@@ -55,7 +57,6 @@ export const PeriodField = ({
           formatWeekDay={(nameOfDay) => nameOfDay.toLowerCase().slice(0, 3)}
           renderCustomHeader={(props) => <CustomHeader {...props} />}
           disabledKeyboardNavigation
-          portalId='datepicker-portal'
         />
       </div>
       <div
@@ -78,7 +79,6 @@ export const PeriodField = ({
           formatWeekDay={(nameOfDay) => nameOfDay.toLowerCase().slice(0, 3)}
           renderCustomHeader={(props) => <CustomHeader {...props} />}
           disabledKeyboardNavigation
-          portalId='datepicker-portal'
         />
       </div>
     </div>

--- a/apps/homepage/src/app/(with-header)/mypage/admin/users/_components/ActiveMembersActionBar.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/users/_components/ActiveMembersActionBar.tsx
@@ -1,7 +1,12 @@
 'use client';
 
 import {AddGenerationContainer} from './add-generation/AddGenerationContainer';
-import {GenerationInfoSection} from './GenerationInfoSection';
+import dynamic from 'next/dynamic';
+
+const GenerationInfoSection = dynamic(
+  () => import('./GenerationInfoSection').then((m) => m.GenerationInfoSection),
+  {ssr: false}
+);
 
 interface ActiveMembersActionBarProps {
   generations: number[];

--- a/apps/homepage/src/app/(with-header)/mypage/admin/users/_components/add-generation/AddGenerationModal.tsx
+++ b/apps/homepage/src/app/(with-header)/mypage/admin/users/_components/add-generation/AddGenerationModal.tsx
@@ -3,7 +3,12 @@
 import {useState} from 'react';
 import Close from '@/assets/modal/close.svg';
 import {Button} from '@repo/ui/components/buttons/Button';
-import {DateField} from './DateField';
+import dynamic from 'next/dynamic';
+
+const DateField = dynamic(
+  () => import('./DateField').then((m) => m.DateField),
+  {ssr: false}
+);
 
 interface AddGenerationModalProps {
   isOpen: boolean;

--- a/apps/recruit/src/app/admin/(with-sidebar)/application-edit/_containers/AdminDatePickerButtonContainer.tsx
+++ b/apps/recruit/src/app/admin/(with-sidebar)/application-edit/_containers/AdminDatePickerButtonContainer.tsx
@@ -1,6 +1,14 @@
 'use client';
 
-import {CustomDateTimePicker} from '@/app/admin/(with-sidebar)/application-edit/_components/calendar/CustomDateTimePicker';
+import dynamic from 'next/dynamic';
+
+const CustomDateTimePicker = dynamic(
+  () =>
+    import(
+      '@/app/admin/(with-sidebar)/application-edit/_components/calendar/CustomDateTimePicker'
+    ).then((m) => m.CustomDateTimePicker),
+  {ssr: false}
+);
 import CalendarIcon from '@repo/ui/assets/icons/calendar.svg';
 import 'react-datepicker/dist/react-datepicker.css';
 import {useMemo, useRef, useState} from 'react';

--- a/apps/recruit/src/components/recruitment/RecruitmentInformation.tsx
+++ b/apps/recruit/src/components/recruitment/RecruitmentInformation.tsx
@@ -1,6 +1,14 @@
 'use client';
 
-import {RecruitmentInfoEditRow} from '@/app/admin/(with-sidebar)/application-edit/_components/recruitment/RecruitmentInfoEditRow';
+import dynamic from 'next/dynamic';
+
+const RecruitmentInfoEditRow = dynamic(
+  () =>
+    import(
+      '@/app/admin/(with-sidebar)/application-edit/_components/recruitment/RecruitmentInfoEditRow'
+    ).then((m) => m.RecruitmentInfoEditRow),
+  {ssr: false}
+);
 import {RecruitmentInfoViewRow} from '@/components/recruitment/RecruitmentInfoViewRow';
 import {scheduleSections} from '@/constants/admin/admin-application-questions';
 import {RecruitmentInformationType} from '@/schemas/admin/admin-recruitment-information.schema';

--- a/packages/tailwind-config/theme/custom-datepicker.css
+++ b/packages/tailwind-config/theme/custom-datepicker.css
@@ -7,7 +7,6 @@
     position: absolute !important;
     left: 0 !important;
     top: 100% !important;
-    transform: none !important;
     margin-top: 8px !important;
   }
 }


### PR DESCRIPTION
## ISSUE 🔗

close #405

<br><br>

## What is this PR? 🔍

### 1. feat(homepage): react-datepicker dynamic import 적용

- **💡 배경**: react-datepicker(gzipped ~52KB)가 정적 import로 초기 번들에 포함돼 있어, 달력 UI를 사용하지 않는 경우에도 해당 코드를 모두 다운로드해야 했습니다.
- **✨ 주요 변경사항**: `AddProjectForm`의 `PeriodField`, `AddGenerationModal`의 `DateField`, `ActiveMembersActionBar`의 `GenerationInfoSection`을 `next/dynamic + ssr: false`로 교체해 달력이 실제로 필요한 시점에만 로드되도록 분리했습니다.

### 2. feat(recruit): react-datepicker dynamic import 적용

- **💡 배경**: homepage와 동일하게 react-datepicker가 초기 번들에 포함돼 있었습니다.
- **✨ 주요 변경사항**: `RecruitmentInformation`의 `RecruitmentInfoEditRow`, `AdminDatePickerButtonContainer`의 `CustomDateTimePicker`를 `next/dynamic + ssr: false`로 교체했습니다.

### 3. fix(homepage): PeriodField `'use client'` 추가 (#405)

- **💡 배경**: `PeriodField`는 `'use client'` 선언 없이 부모 컴포넌트의 클라이언트 컨텍스트를 상속받고 있었습니다. dynamic import로 별도 청크가 되면서 자체 선언이 필요해졌습니다.
- **✨ 주요 변경사항**: `'use client'` 추가

### 4. fix(homepage): datepicker 위치 오류 수정 (#405)

- **💡 배경**: PC에서 달력 팝업이 화면 맨 아래에 렌더링되는 버그가 있었습니다. `custom-datepicker.css`의 `transform: none !important;`가 Popper.js의 위치 계산을 덮어써서 발생한 문제였습니다. 모바일에서는 HeroMainBanner 위에 달력이 표시되어야 하므로 `portalId='datepicker-portal'`은 유지가 필요합니다.
- **✨ 주요 변경사항**: `custom-datepicker.css`에서 `transform: none !important;` 제거

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->

<br><br>

## Test Checklist ✔

- [x] homepage `/project/add-project` — 기간 선택 달력 PC/모바일 위치 정상 확인
- [x] homepage `/mypage/admin/users` — 기수 추가 달력 정상 동작 확인 (admin 권한 필요)
- [ ] recruit admin 모집 일정 편집 — 날짜 선택 달력 정상 동작 확인 (서버 미접속으로 로컬 확인 불가 — 배포 후 확인 필요)