### PR TITLE
[CHORE]: google 사이트 인증 메타 태그 추가

### DIFF
--- a/apps/homepage/src/app/layout.tsx
+++ b/apps/homepage/src/app/layout.tsx
@@ -59,6 +59,9 @@ export const metadata: Metadata = {
       'max-snippet': -1,
     },
   },
+  verification: {
+    google: 'U9oZYgH8MZIHDHHr9HptzFTZIjUgHHXaB5es3_D76hY',
+  },
 };
 
 const pretendard = localFont({


### PR DESCRIPTION
## ISSUE 🔗

close #419

<br><br>

## What is this PR? 🔍

- **💡 배경**: Google Search Console에서 홈페이지(cotato.kr) 소유권 인증을 위해 사이트 인증 태그가 필요했습니다.
- **✨ 주요 변경사항**: Next.js App Router의 `Metadata` API에서 제공하는 `verification.google` 필드를 `apps/homepage/src/app/layout.tsx`에 추가했습니다. 이를 통해 `<meta name="google-site-verification" content="..." />` 태그가 자동으로 렌더링됩니다.
- **🧪 리뷰 포인트**: `<head>`를 직접 수정하지 않고 Next.js 공식 Metadata API를 활용했습니다.

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->

<br><br>

## Test Checklist ✔

- [ ] 프로덕션 빌드 후 `<head>`에 `google-site-verification` 메타 태그가 정상 출력되는지 확인
- [ ] Google Search Console에서 소유권 인증이 완료되는지 확인