### PR TITLE
[CHORE]: Google 사이트 인증 메타 태그 recruit 앱 추가

### DIFF
--- a/apps/recruit/src/app/layout.tsx
+++ b/apps/recruit/src/app/layout.tsx
@@ -62,6 +62,9 @@ export const metadata: Metadata = {
       'max-snippet': -1,
     },
   },
+  verification: {
+    google: 'U9oZYgH8MZIHDHHr9HptzFTZIjUgHHXaB5es3_D76hY',
+  },
 };
 
 const pretendard = localFont({


### PR DESCRIPTION
## ISSUE 🔗

close #422

<br><br>

## What is this PR? 🔍

### chore(recruit): recruit 앱 Google 사이트 인증 메타 태그 추가

- **💡 배경**: homepage에 이어 recruit(recruit.cotato.kr) 도메인도 Google Search Console 인증이 필요했습니다.
- **✨ 주요 변경사항**: `apps/recruit` `layout.tsx`의 metadata에 동일하게 `verification.google` 필드를 추가했습니다.

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->

<br><br>

## Test Checklist ✔

- [ ] cotato.kr Google Search Console 사이트 인증 통과 확인
- [ ] recruit.cotato.kr Google Search Console 사이트 인증 통과 확인
- [ ] 각 앱 빌드 후 `<meta name="google-site-verification" ...>` 태그 렌더링 확인